### PR TITLE
Embed eeasy-internal booking iframe on thanks pages

### DIFF
--- a/src/app/applicants/new/page.tsx
+++ b/src/app/applicants/new/page.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import BookingEmbed from "@/app/components/BookingEmbed";
 import JobCard from "@/app/components/JobCard";
 import type { Job } from "@/lib/microcms";
 
@@ -118,14 +119,7 @@ export default function ApplicationComplete() {
               高年収の求人から採用枠が埋まります。少しでも早く知りたい方は、こちらから面談日程のご予約ください。
             </p>
             <div className="mt-6">
-              <Link
-                href="https://eeasy-internal.vercel.app/book/ride"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block rounded-2xl bg-[#2205D9] py-4 text-center text-lg font-semibold text-white shadow-[0_6px_0_rgba(0,0,0,0.15)] transition-transform hover:translate-y-[1px]"
-              >
-                面談予約へ
-              </Link>
+              <BookingEmbed slug="ride" />
             </div>
           </div>
         </section>

--- a/src/app/bus/applicants/new/page.tsx
+++ b/src/app/bus/applicants/new/page.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import BookingEmbed from "@/app/components/BookingEmbed";
 import JobCard from "@/app/components/JobCard";
 import type { Job } from "@/lib/microcms";
 
@@ -118,14 +119,7 @@ export default function BusApplicationComplete() {
               高年収の求人から採用枠が埋まります。少しでも早く知りたい方は、こちらから面談日程のご予約ください。
             </p>
             <div className="mt-6">
-              <Link
-                href="https://eeasy-internal.vercel.app/book/ride"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block rounded-2xl bg-[#2205D9] py-4 text-center text-lg font-semibold text-white shadow-[0_6px_0_rgba(0,0,0,0.15)] transition-transform hover:translate-y-[1px]"
-              >
-                面談予約へ
-              </Link>
+              <BookingEmbed slug="ride" />
             </div>
           </div>
         </section>

--- a/src/app/components/BookingEmbed.tsx
+++ b/src/app/components/BookingEmbed.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+type BookingEmbedProps = {
+  slug: string;
+  height?: number;
+  className?: string;
+};
+
+export default function BookingEmbed({
+  slug,
+  height = 1600,
+  className = '',
+}: BookingEmbedProps) {
+  const src = `https://eeasy-internal.vercel.app/book/${slug}`;
+
+  return (
+    <div
+      className={`overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-[0_8px_20px_rgba(0,0,0,0.06)] ${className}`}
+    >
+      <iframe
+        src={src}
+        title="面談予約フォーム"
+        loading="lazy"
+        className="block w-full"
+        style={{ height: `${height}px`, border: 'none' }}
+        allow="clipboard-write"
+      />
+    </div>
+  );
+}

--- a/src/app/coupang/applicants/new/page.tsx
+++ b/src/app/coupang/applicants/new/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from "react";
+import BookingEmbed from "@/app/components/BookingEmbed";
 
 declare global {
   interface Window {
@@ -41,14 +42,7 @@ export default function CoupangApplicationComplete() {
           <p>{currentMonth}から求人の問い合わせが急増しており、ご希望日時に面談枠をご用意できないことがあります。</p>
           <p>空き枠があるうちに、以下より日程をご予約ください。</p>
         </div>
-        <a
-          href="https://eeasy-internal.vercel.app/book/cpj"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="block w-full bg-[#ff6b35] hover:bg-[#e55a2b] text-white font-bold py-4 px-6 rounded-lg text-center transition-colors"
-        >
-          面談予約へ<br />
-        </a>
+        <BookingEmbed slug="cpj" />
       </div>
 
       {/* Footer */}

--- a/src/app/mechanic/applicants/new/page.tsx
+++ b/src/app/mechanic/applicants/new/page.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import BookingEmbed from "@/app/components/BookingEmbed";
 import JobCard from "@/app/components/JobCard";
 import type { Job } from "@/lib/microcms";
 
@@ -120,14 +121,7 @@ export default function MechanicApplicationComplete() {
           </div>
 
           <div className="mt-6">
-            <Link
-              href="https://eeasy-internal.vercel.app/book/mec"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="block rounded-2xl bg-[#2205D9] py-4 text-center text-lg font-semibold text-white shadow-[0_6px_0_rgba(0,0,0,0.15)] transition-transform hover:translate-y-[1px]"
-            >
-              面談予約へ
-            </Link>
+            <BookingEmbed slug="mec" />
           </div>
         </section>
 


### PR DESCRIPTION
Replace the external 面談予約 button link on the 4 thanks pages (ride, bus, mechanic, coupang) with an inline iframe of the matching eeasy-internal /book/[slug] page via a new BookingEmbed component, so applicants can schedule a slot without leaving the LP.