### PR TITLE
郵便番号から取得した町域(townName)を通知・保存に反映

### DIFF
--- a/src/app/api/applicants/route.ts
+++ b/src/app/api/applicants/route.ts
@@ -32,6 +32,7 @@ type ApplicantFormData = {
   prefectureName?: string;
   municipalityId?: string;
   municipalityName?: string;
+  townName?: string;
   phoneNumber?: string;
   email?: string;
   jobTiming?: FormData['jobTiming'];
@@ -210,8 +211,8 @@ export async function POST(request: NextRequest) {
         const utmDisplay = utmParams?.utm_source
           ? `${utmParams.utm_source}${utmParams.utm_medium ? `(${utmParams.utm_medium})` : ''}`
           : 'RIDEJOB HP';
-        const locationDisplay = formData.prefectureName || formData.municipalityName
-          ? `${formData.prefectureName || ''} ${formData.municipalityName || ''}`.trim()
+        const locationDisplay = formData.prefectureName || formData.municipalityName || formData.townName
+          ? `${formData.prefectureName || ''} ${formData.municipalityName || ''} ${formData.townName || ''}`.replace(/\s+/g, ' ').trim()
           : '未入力';
         const mechanicQualificationsDisplay = isMechanic && mechanicQualificationsLabel
           ? `${qualificationFieldLabel}: ${mechanicQualificationsLabel}`
@@ -283,6 +284,7 @@ ${additionalFields ? `${additionalFields}\n` : ''}電話番号: ${formData.phone
           prefecture_name: formData.prefectureName || '',
           municipality_id: formData.municipalityId || '',
           municipality_name: formData.municipalityName || '',
+          town_name: formData.townName || '',
           phone_number: formData.phoneNumber || '',
           email: formData.email || '',
           job_timing: baseJobTimingLabel,
@@ -384,6 +386,7 @@ ${additionalFields ? `${additionalFields}\n` : ''}電話番号: ${formData.phone
           prefecture_name: formData.prefectureName || '',
           municipality_id: formData.municipalityId || '',
           municipality_name: formData.municipalityName || '',
+          town_name: formData.townName || '',
           phone_number: formData.phoneNumber || '',
           email: formData.email || '',
           job_timing: baseJobTimingLabel,

--- a/src/app/components/application-form/hooks/useApplicationFormState.ts
+++ b/src/app/components/application-form/hooks/useApplicationFormState.ts
@@ -601,6 +601,7 @@ export function useApplicationFormState({ showLoadingScreen, imagesToPreload, va
         let municipalityName = formData.municipalityId
           ? await fetchMunicipalityName(formData.municipalityId)
           : '';
+        let townName = '';
 
         // 郵便番号が入力されている場合、ZipCloud APIから住所情報を取得
         if (formData.postalCode && !formData.prefectureId && !formData.municipalityId) {
@@ -609,6 +610,7 @@ export function useApplicationFormState({ showLoadingScreen, imagesToPreload, va
           if (addressInfo) {
             prefectureName = addressInfo.prefectureName || '';
             municipalityName = addressInfo.municipalityName || '';
+            townName = addressInfo.townName || '';
           }
         }
 
@@ -617,6 +619,7 @@ export function useApplicationFormState({ showLoadingScreen, imagesToPreload, va
           birthDate: birthDateString,
           prefectureName,
           municipalityName,
+          townName,
           utmParams,
           experiment: { name: 'people_image', variant },
           formOrigin,


### PR DESCRIPTION
## 概要
ZipCloud API が返す町域(`address3`)を、フォーム送信時に拾わず破棄していたため、Lark 通知の「地域」表示が市区町村までしか出ていなかった。`townName` をパイプライン全体に通すよう修正。

## 変更内容
- フォーム送信処理: ZipCloud から取得した `townName` を送信ボディに追加
- 応募API: 型に `townName` を追加、Lark 通知の「地域」を `都道府県 市区町村 町域` まで表示、Base 送信ペイロードに `town_name` を追加

## 効果
郵便番号を入力すれば町域まで自動で通知に出るようになり、都度のネット検索が不要になる。
例: 「鹿児島県 霧島市」→「鹿児島県 霧島市 霧島田口」

## テスト
- `npx tsc --noEmit` で型チェック通過
- dev サーバーで実際に POST 送信し、テスト用 Lark チャンネルへ通知成功を確認(StatusMessage: success)

## 補足
Base/スプレッドシート側で `town_name` を列保存したい場合は受信側(GAS等)に列マッピング追加が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)