### PR TITLE
feat(applicants): Lark BaseのpayloadにページURL(referer)を追加

### DIFF
--- a/src/app/api/applicants/route.ts
+++ b/src/app/api/applicants/route.ts
@@ -300,6 +300,7 @@ ${additionalFields ? `${additionalFields}\n` : ''}電話番号: ${formData.phone
           client_ip: clientIp,
           form_origin: formOrigin || '',
           is_coupang: isCoupang,
+          page_url: referer,
         } as Record<string, unknown>;
 
         tasks.push(
@@ -425,6 +426,7 @@ ${additionalFields ? `${additionalFields}\n` : ''}電話番号: ${formData.phone
           client_ip: clientIp,
           form_origin: formOrigin || '',
           is_coupang: isCoupang,
+          page_url: referer,
         } as Record<string, unknown>;
 
         const resp = await fetch(baseWebhookUrl, {


### PR DESCRIPTION
## 概要
Lark Base 登録用 `basePayload` に応募ページのURL(Referer ヘッダ)を `page_url` として追加。

## 変更点
- `src/app/api/applicants/route.ts`
  - 通常モード(並列送信)の basePayload に `page_url: referer` を追加
  - Baseのみテストモード(`LARK_SEND_BASE_ONLY=true`)の basePayload にも同様に追加
- 値の元は既存の `request.headers.get('referer') || ''`(L130)

## Lark Base 側の対応(要確認)
受け取るには対象テーブルに `page_url`(テキスト型)フィールドと Webhook マッピングの追加が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)