### PR TITLE
feat(meta): 応募時にMeta広告画像URLを解決しpayloadに追加

### DIFF
--- a/src/app/api/applicants/route.ts
+++ b/src/app/api/applicants/route.ts
@@ -8,6 +8,7 @@ import {
   sendApplicationConfirmationEmail,
 } from '@/lib/email/send-application-confirmation';
 import { sendApplicationSms } from '@/lib/sms/send-application-sms';
+import { resolveAdImageUrl, isLikelyAdId } from '@/lib/meta/resolveAdImage';
 
 // Types for submission payload
 type ExperimentInfo = {
@@ -21,6 +22,7 @@ type UTMParams = {
   utm_campaign?: string;
   utm_term?: string;
   utm_creative?: string;
+  utm_content?: string; // Meta広告: {{ad.id}} を想定
 };
 
 type ApplicantFormData = {
@@ -199,7 +201,26 @@ export async function POST(request: NextRequest) {
     const baseJobIntentLabel = isMechanicNewgrad ? '' : jobIntentLabel;
     const baseDesiredIncomeLabel = isMechanicNewgrad ? '' : desiredIncomeLabel;
     console.log('Generated media name:', mediaName, 'isCoupang:', isCoupang);
-    
+
+    // Meta広告の広告ID(ad.id)から広告画像URLを解決する。
+    // 入稿URLに utm_content={{ad.id}} を仕込む想定。後方互換で utm_creative が数値なら ad.id とみなす。
+    const isMetaInflowForImage = isCoupang || (utmParams?.utm_source || '').toLowerCase() === 'meta';
+    const adId = isLikelyAdId(utmParams?.utm_content)
+      ? (utmParams?.utm_content as string)
+      : isLikelyAdId(utmParams?.utm_creative)
+        ? (utmParams?.utm_creative as string)
+        : '';
+    let adImageUrl = '';
+    let adCreativeId = '';
+    if (isMetaInflowForImage && adId) {
+      const resolved = await resolveAdImageUrl(adId);
+      if (resolved) {
+        adImageUrl = resolved.imageUrl || '';
+        adCreativeId = resolved.creativeId || '';
+      }
+      console.log('Resolved Meta ad image:', { adId, adImageUrl: adImageUrl ? '(取得済)' : '(なし)', adCreativeId });
+    }
+
     // 並列送信（Baseのみテスト中は直下の単独送信へ）
     if (!sendBaseOnly) {
       const tasks: Promise<void>[] = [];
@@ -277,6 +298,10 @@ ${additionalFields ? `${additionalFields}\n` : ''}電話番号: ${formData.phone
           utm_campaign: utmParams?.utm_campaign || '',
           utm_term: utmParams?.utm_term || '',
           utm_creative: utmParams?.utm_creative || '',
+          utm_content: utmParams?.utm_content || '',
+          ad_id: adId,
+          ad_creative_id: adCreativeId,
+          ad_image_url: adImageUrl,
           birth_date: formData.birthDate || '',
           full_name: formData.fullName || '',
           full_name_kana: formData.fullNameKana || '',
@@ -403,6 +428,10 @@ ${additionalFields ? `${additionalFields}\n` : ''}電話番号: ${formData.phone
           utm_campaign: utmParams?.utm_campaign || '',
           utm_term: utmParams?.utm_term || '',
           utm_creative: utmParams?.utm_creative || '',
+          utm_content: utmParams?.utm_content || '',
+          ad_id: adId,
+          ad_creative_id: adCreativeId,
+          ad_image_url: adImageUrl,
           birth_date: formData.birthDate || '',
           full_name: formData.fullName || '',
           full_name_kana: formData.fullNameKana || '',

--- a/src/app/api/coupang/applicants/route.ts
+++ b/src/app/api/coupang/applicants/route.ts
@@ -5,6 +5,7 @@ import {
   LOCATION_LABELS,
 } from '@/app/components/coupang-form/constants';
 import { getCoupangStep1Options } from '../step1-options/options';
+import { resolveAdImageUrl, isLikelyAdId } from '@/lib/meta/resolveAdImage';
 
 type UTMParams = {
   utm_source?: string;
@@ -12,6 +13,7 @@ type UTMParams = {
   utm_campaign?: string;
   utm_term?: string;
   utm_creative?: string;
+  utm_content?: string; // Meta広告: {{ad.id}} を想定
 };
 
 type CoupangSubmission = CoupangFormData & {
@@ -71,6 +73,24 @@ export async function POST(request: NextRequest) {
       : '未選択';
     const ageLabel = formData.age ? `${formData.age}歳` : '未選択';
     const birthDateLabel = formData.birthDate || '未入力';
+
+    // Meta広告の広告ID(ad.id)から広告画像URLを解決する（Coupangは常にMeta流入）。
+    // 入稿URLに utm_content={{ad.id}} を仕込む想定。後方互換で utm_creative が数値なら ad.id とみなす。
+    const adId = isLikelyAdId(utmParams?.utm_content)
+      ? (utmParams?.utm_content as string)
+      : isLikelyAdId(utmParams?.utm_creative)
+        ? (utmParams?.utm_creative as string)
+        : '';
+    let adImageUrl = '';
+    let adCreativeId = '';
+    if (adId) {
+      const resolved = await resolveAdImageUrl(adId);
+      if (resolved) {
+        adImageUrl = resolved.imageUrl || '';
+        adCreativeId = resolved.creativeId || '';
+      }
+      console.log('Resolved Meta ad image (coupang):', { adId, adImageUrl: adImageUrl ? '(取得済)' : '(なし)', adCreativeId });
+    }
 
     // 並列送信
     if (!sendBaseOnly) {
@@ -132,6 +152,10 @@ export async function POST(request: NextRequest) {
           utm_campaign: utmParams?.utm_campaign || '',
           utm_term: utmParams?.utm_term || '',
           utm_creative: utmParams?.utm_creative || '',
+          utm_content: utmParams?.utm_content || '',
+          ad_id: adId,
+          ad_creative_id: adCreativeId,
+          ad_image_url: adImageUrl,
           email: formData.email || '',
           full_name: formData.fullName || '',
           full_name_kana: formData.fullNameKana || '',
@@ -178,6 +202,10 @@ export async function POST(request: NextRequest) {
           utm_campaign: utmParams?.utm_campaign || '',
           utm_term: utmParams?.utm_term || '',
           utm_creative: utmParams?.utm_creative || '',
+          utm_content: utmParams?.utm_content || '',
+          ad_id: adId,
+          ad_creative_id: adCreativeId,
+          ad_image_url: adImageUrl,
           email: formData.email || '',
           full_name: formData.fullName || '',
           full_name_kana: formData.fullNameKana || '',

--- a/src/app/components/application-form/hooks/useApplicationFormState.ts
+++ b/src/app/components/application-form/hooks/useApplicationFormState.ts
@@ -590,6 +590,7 @@ export function useApplicationFormState({ showLoadingScreen, imagesToPreload, va
           utm_campaign: urlParams.get('utm_campaign') || '',
           utm_term: urlParams.get('utm_term') || '',
           utm_creative: urlParams.get('utm_creative') || '',
+          utm_content: urlParams.get('utm_content') || '', // Meta広告: {{ad.id}} を想定
         };
 
         const birthDateString = formData.birthDate.length === 8

--- a/src/app/components/coupang-form/hooks/useCoupangForm.ts
+++ b/src/app/components/coupang-form/hooks/useCoupangForm.ts
@@ -79,6 +79,7 @@ export function useCoupangForm() {
         utm_campaign: urlParams.get('utm_campaign') || undefined,
         utm_term: urlParams.get('utm_term') || undefined,
         utm_creative: urlParams.get('utm_creative') || undefined,
+        utm_content: urlParams.get('utm_content') || undefined, // Meta広告: {{ad.id}} を想定
       };
 
       // GTMイベント送信

--- a/src/app/components/coupang-form/hooks/useCoupangFormState.ts
+++ b/src/app/components/coupang-form/hooks/useCoupangFormState.ts
@@ -192,6 +192,7 @@ export function useCoupangFormState() {
           utm_campaign: urlParams.get('utm_campaign') || undefined,
           utm_term: urlParams.get('utm_term') || undefined,
           utm_creative: urlParams.get('utm_creative') || undefined,
+          utm_content: urlParams.get('utm_content') || undefined, // Meta広告: {{ad.id}} を想定
         };
 
         // GTMイベント送信

--- a/src/lib/meta/resolveAdImage.ts
+++ b/src/lib/meta/resolveAdImage.ts
@@ -1,0 +1,100 @@
+/**
+ * Meta Marketing API: 広告ID(ad.id)から広告クリエイティブの画像URLを解決する。
+ *
+ * 流入URLに仕込んだ {{ad.id}} を受け取り、
+ *   ad → creative → image_url
+ * の経路でクリエイティブ画像URLを取得する。
+ *
+ * 注意:
+ * - 返る image_url は fbcdn の署名付きURLで、取得から約4〜5日で失効する（MVP方針: そのまま保存）。
+ * - 応募処理を止めないため、失敗・タイムアウト時は null を返すだけにする（呼び出し側で握りつぶす）。
+ */
+
+const GRAPH_VERSION = process.env.META_GRAPH_VERSION || 'v23.0';
+const DEFAULT_TIMEOUT_MS = 2500;
+
+export type ResolvedAdImage = {
+  adId: string;
+  creativeId: string | null;
+  imageUrl: string | null;
+  imageHash: string | null;
+};
+
+type GraphCreative = {
+  id?: string;
+  image_url?: string;
+  image_hash?: string;
+  object_story_spec?: {
+    link_data?: { picture?: string; image_hash?: string };
+    video_data?: { image_url?: string; image_hash?: string; video_id?: string };
+  };
+};
+
+type GraphAdResponse = {
+  creative?: GraphCreative;
+  error?: { message?: string };
+};
+
+/** ad.id らしき値か（Metaの広告IDは数字のみ） */
+export function isLikelyAdId(value: string | undefined | null): value is string {
+  return !!value && /^\d{5,}$/.test(value.trim());
+}
+
+/**
+ * ad.id から画像URLを解決する。失敗時は null。
+ */
+export async function resolveAdImageUrl(
+  adId: string,
+  options?: { timeoutMs?: number; token?: string },
+): Promise<ResolvedAdImage | null> {
+  const token = options?.token ?? process.env.META_ACCESS_TOKEN;
+  if (!token) {
+    console.warn('[meta] META_ACCESS_TOKEN is not configured. Skipping ad image resolution.');
+    return null;
+  }
+  if (!isLikelyAdId(adId)) {
+    return null;
+  }
+
+  const params = new URLSearchParams({
+    fields: 'creative{id,image_url,image_hash,object_story_spec}',
+    access_token: token,
+  });
+  const url = `https://graph.facebook.com/${GRAPH_VERSION}/${adId}?${params.toString()}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), options?.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+
+  try {
+    const resp = await fetch(url, { signal: controller.signal });
+    const data = (await resp.json()) as GraphAdResponse;
+
+    if (!resp.ok || data.error) {
+      console.warn('[meta] ad image resolution failed:', data.error?.message || resp.status);
+      return null;
+    }
+
+    const c = data.creative;
+    if (!c) return null;
+
+    const oss = c.object_story_spec || {};
+    const imageUrl = c.image_url || oss.video_data?.image_url || oss.link_data?.picture || null;
+    const imageHash = c.image_hash || oss.video_data?.image_hash || oss.link_data?.image_hash || null;
+
+    return {
+      adId,
+      creativeId: c.id ?? null,
+      imageUrl,
+      imageHash,
+    };
+  } catch (error) {
+    if ((error as Error)?.name === 'AbortError') {
+      console.warn('[meta] ad image resolution timed out for adId:', adId);
+    } else {
+      console.warn('[meta] ad image resolution error:', error);
+    }
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
## 概要
Meta広告から流入した応募について、広告ID(`ad.id`)を起点に広告クリエイティブの画像URLを取得し、Lark Base への payload に含める。

## 変更点
- 各フォームで `utm_content`(=`{{ad.id}}` 想定)を取得
- `src/lib/meta/resolveAdImage.ts` を新規追加: `ad.id → creative → image_url` を解決（タイムアウト2.5秒・失敗時nullで応募処理は止めない）
- `applicants` / `coupang/applicants` 両APIの Lark Base payload に `ad_id` / `ad_creative_id` / `ad_image_url` / `utm_content` を追加

## デプロイ前の必須対応 ⚠️
- 本番環境(ホスティング)に環境変数 `META_ACCESS_TOKEN` と `META_GRAPH_VERSION=v23.0` を設定すること（`.env.local`はデプロイされない）
- Meta広告マネージャの各広告「URLパラメータ」に `utm_source=meta&utm_medium=ad&utm_content={{ad.id}}` を設定
- Lark Base テーブルに `ad_image_url` / `ad_id` / `ad_creative_id` / `utm_content` 列を追加

## 既知の制約（MVP/案A）
- `ad_image_url` は fbcdn の署名付きURLで取得から約4〜5日で失効。恒久化が必要なら後続で再ホスト対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)