### PR TITLE
応募SMSを流入元で絞らず全応募者に送信

### DIFF
--- a/src/app/api/applicants/route.ts
+++ b/src/app/api/applicants/route.ts
@@ -119,6 +119,12 @@ function getMediaName(utmParams: { utm_source?: string; utm_medium?: string }): 
   }
 }
 
+// Meta(Facebook/Instagram)広告の流入判定。広告側UTMは utm_source=fb 等で来るため複数表記を許容する。
+const META_UTM_SOURCES = new Set(['meta', 'fb', 'facebook', 'ig', 'instagram']);
+function isMetaUtmSource(utmSource?: string): boolean {
+  return META_UTM_SOURCES.has((utmSource || '').toLowerCase());
+}
+
 export async function POST(request: NextRequest) {
   try {
     const submissionData = (await request.json()) as ApplicantSubmission;
@@ -204,7 +210,7 @@ export async function POST(request: NextRequest) {
 
     // Meta広告の広告ID(ad.id)から広告画像URLを解決する。
     // 入稿URLに utm_content={{ad.id}} を仕込む想定。後方互換で utm_creative が数値なら ad.id とみなす。
-    const isMetaInflowForImage = isCoupang || (utmParams?.utm_source || '').toLowerCase() === 'meta';
+    const isMetaInflowForImage = isCoupang || isMetaUtmSource(utmParams?.utm_source);
     const adId = isLikelyAdId(utmParams?.utm_content)
       ? (utmParams?.utm_content as string)
       : isLikelyAdId(utmParams?.utm_creative)
@@ -391,24 +397,26 @@ ${additionalFields ? `${additionalFields}\n` : ''}電話番号: ${formData.phone
         );
       }
 
-      // 新規応募SMS(Meta流入・ライド/メカのみ)。電話はフォームで取得済み。
-      // 送信本体は eeasy の共通エンドポイントに委譲(文面/送信/効果測定記録を一元化)。
-      const isMetaInflow = (utmParams?.utm_source || '').toLowerCase() === 'meta';
+      // 新規応募SMS(ライド/メカの全応募者)。流入元では絞らない(電話を残した応募者に予約リンクを送る)。
+      // coupang / bus は対象外(smsChannel=null)。送信本体は eeasy の共通エンドポイントに委譲。
+      // media には実際の流入元(utm_source)を渡す。無ければ 'form'。
       const smsChannel: 'ridejob' | 'mechanic' | null =
         isCoupang || formOrigin === 'bus' ? null : isMechanic ? 'mechanic' : 'ridejob';
-      if (isMetaInflow && smsChannel && formData.phoneNumber) {
+      if (smsChannel && formData.phoneNumber) {
         const channel = smsChannel;
+        const media = (utmParams?.utm_source || 'form').toLowerCase().slice(0, 32);
         tasks.push(
           (async () => {
             const r = await sendApplicationSms({
               channel,
               phone: formData.phoneNumber,
               applicantName: formData.fullName,
+              media,
             });
             if (r.sent) {
-              console.log('Meta SMS sent:', { order: r.deliveryOrderId, ref: r.ref, channel });
+              console.log('Application SMS sent:', { order: r.deliveryOrderId, ref: r.ref, channel, media });
             } else {
-              console.log('Meta SMS skipped/failed:', { reason: r.reason, error: r.error, channel });
+              console.log('Application SMS skipped/failed:', { reason: r.reason, error: r.error, channel, media });
             }
           })()
         );

--- a/src/lib/sms/send-application-sms.ts
+++ b/src/lib/sms/send-application-sms.ts
@@ -1,5 +1,5 @@
 /**
- * 新規応募SMS送信の高レベル API(Meta流入のフォーム応募者向け)。
+ * 新規応募SMS送信の高レベル API(ライド/メカのフォーム応募者向け・流入元不問)。
  *
  * 送信本体は eeasy(leomeet) の共通エンドポイント /api/sms/send に委譲する
  * (文面・事業部マッピング・CPaaS送信・効果測定記録は eeasy 側に一元化)。
@@ -29,6 +29,8 @@ export async function sendApplicationSms(input: {
   channel: SmsChannel;
   phone?: string;
   applicantName?: string;
+  /** 流入元ラベル(eeasy の sms_messages.media に記録)。未指定は 'form'。 */
+  media?: string;
 }): Promise<SmsSendResult> {
   if (process.env.META_SMS_ENABLED !== 'true') {
     return { sent: false, reason: 'disabled' };
@@ -56,7 +58,7 @@ export async function sendApplicationSms(input: {
       body: JSON.stringify({
         phone: input.phone,
         channel: input.channel,
-        media: 'meta',
+        media: input.media || 'form',
         applicantName: input.applicantName || undefined,
       }),
     });


### PR DESCRIPTION
## 背景
管理画面で meta経路のSMSが0件だった真因は、フォームのSMS発火条件が `utm_source==='meta'` だったこと。実際のMeta広告流入は `utm_source=fb`(medium=ad)で来るため一度も発火していなかった。eeasy受け口は test A で認証OK・正常稼働を確認済み。

## 変更
- SMS発火条件から `utm_source` フィルターを撤去。**ライド/メカの全応募者(電話あり)**に予約SMSを送信(coupang/bus は対象外を維持)
- eeasy へ渡す `media` を `'meta'` 固定から**実際の utm_source(無ければ `form`)**に変更 → 管理画面で流入元を可視化
- 広告画像取得の Meta判定を `fb/facebook/meta/ig/instagram` に拡張(fb流入の画像取得漏れ解消)

## デプロイ後の確認
utm_source=fb のテスト応募1件で eeasy 管理画面に `media=fb` 行が出ること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)