### PR TITLE
feat: 応募LPを ridejob.jp/entry 配下へ複製（マルチゾーン・basePath対応）

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  // マルチゾーン配信: ridejob.jp 配下へ複製する deployment でのみ NEXT_PUBLIC_BASE_PATH=/entry を設定する。
+  // 既存の ridejob.pmagent.jp（単独ドメイン）deployment では未設定＝basePathなし（挙動不変）。
+  basePath: process.env.NEXT_PUBLIC_BASE_PATH || undefined,
   images: {
     // Vercelで自動的にAVIF/WebP形式に変換
     formats: ['image/avif', 'image/webp'],

--- a/src/app/applicants/new/page.tsx
+++ b/src/app/applicants/new/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { apiPath } from '@/lib/basePath';
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
@@ -42,7 +43,7 @@ export default function ApplicationComplete() {
   useEffect(() => {
     const fetchJobs = async () => {
       try {
-        const response = await fetch('/api/jobs/random?categoryId=6&count=3');
+        const response = await fetch(apiPath('/api/jobs/random?categoryId=6&count=3'));
         if (!response.ok) {
           console.error('Failed to fetch jobs');
           setIsLoadingJobs(false);

--- a/src/app/bus/applicants/new/page.tsx
+++ b/src/app/bus/applicants/new/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { apiPath } from '@/lib/basePath';
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
@@ -42,7 +43,7 @@ export default function BusApplicationComplete() {
   useEffect(() => {
     const fetchJobs = async () => {
       try {
-        const response = await fetch('/api/jobs/random?categoryId=5&prefectureIds=13,14&count=3');
+        const response = await fetch(apiPath('/api/jobs/random?categoryId=5&prefectureIds=13,14&count=3'));
         if (!response.ok) {
           console.error('Failed to fetch jobs');
           setIsLoadingJobs(false);

--- a/src/app/components/application-form/components/NameCard.tsx
+++ b/src/app/components/application-form/components/NameCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { apiPath } from '@/lib/basePath';
 import { useEffect, useMemo, useState } from 'react';
 
 import Image from 'next/image';
@@ -47,7 +48,7 @@ export default function NameCard({ stepImageSrc, postalCode, prefectureId, munic
     const loadPrefectures = async () => {
       setIsPrefectureLoading(true);
       try {
-        const response = await fetch('/api/location/prefectures');
+        const response = await fetch(apiPath('/api/location/prefectures'));
         if (!response.ok) {
           throw new Error('Failed to load prefectures');
         }
@@ -90,7 +91,7 @@ export default function NameCard({ stepImageSrc, postalCode, prefectureId, munic
     const loadMunicipalities = async () => {
       setIsMunicipalityLoading(true);
       try {
-        const response = await fetch(`/api/location/municipalities?prefectureId=${prefectureId}`);
+        const response = await fetch(apiPath(`/api/location/municipalities?prefectureId=${prefectureId}`));
         if (!response.ok) {
           throw new Error('Failed to load municipalities');
         }

--- a/src/app/components/application-form/hooks/useApplicationFormState.ts
+++ b/src/app/components/application-form/hooks/useApplicationFormState.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { apiPath } from '@/lib/basePath';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
@@ -626,7 +627,7 @@ export function useApplicationFormState({ showLoadingScreen, imagesToPreload, va
           formOrigin,
         } as Record<string, unknown>;
 
-        const response = await fetch('/api/applicants', {
+        const response = await fetch(apiPath('/api/applicants'), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body),

--- a/src/app/components/application-form/utils/fetchJobCount.ts
+++ b/src/app/components/application-form/utils/fetchJobCount.ts
@@ -1,3 +1,4 @@
+import { apiPath } from '@/lib/basePath';
 type JobCountResponse = {
   jobCount: number | null;
   message: string;
@@ -24,7 +25,7 @@ export async function fetchJobCount(params: JobCountParams): Promise<JobCountRes
     query.set('jobCategoryIds', params.jobCategoryIds.join(','));
   }
 
-  const response = await fetch(`/api/jobs-count?${query.toString()}`);
+  const response = await fetch(apiPath(`/api/jobs-count?${query.toString()}`));
   const data: JobCountResponse = await response.json();
   if (!response.ok) {
     throw new Error(data.error || '求人件数の取得に失敗しました');

--- a/src/app/components/application-form/utils/notifyInvalidPhoneNumber.ts
+++ b/src/app/components/application-form/utils/notifyInvalidPhoneNumber.ts
@@ -1,10 +1,11 @@
+import { apiPath } from '@/lib/basePath';
 import type { FormData } from '../types';
 
 type NotifyPayload = Pick<FormData, 'fullName' | 'phoneNumber'>;
 
 export async function notifyInvalidPhoneNumber(payload: NotifyPayload) {
   try {
-    await fetch('/api/notify_invalid_phone', {
+    await fetch(apiPath('/api/notify_invalid_phone'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),

--- a/src/app/components/coupang-form/CoupangApplicationForm.legacy.tsx
+++ b/src/app/components/coupang-form/CoupangApplicationForm.legacy.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { BASE_PATH } from '@/lib/basePath';
 import Image from 'next/image';
 import { FormSection, TextInput, SelectInput } from './components';
 import { useCoupangForm } from './hooks/useCoupangForm';
@@ -336,7 +337,7 @@ export default function CoupangApplicationForm() {
         <div className="container mx-auto px-4">
           <div className="flex flex-col md:flex-row justify-around items-center text-center md:text-left text-xs mb-3 space-y-2 md:space-y-0">
             <a href="https://pmagent.jp/" className="text-white hover:underline">運営会社について</a>
-            <a href="/privacy" className="text-white hover:underline">プライバシーポリシー</a>
+            <a href={`${BASE_PATH}/privacy`} className="text-white hover:underline">プライバシーポリシー</a>
           </div>
           <div className="text-center mt-3">
             <p className="text-xs">© 2025 株式会社PMAgent</p>

--- a/src/app/components/coupang-form/CoupangApplicationForm.tsx
+++ b/src/app/components/coupang-form/CoupangApplicationForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { BASE_PATH } from '@/lib/basePath';
 import Image from 'next/image';
 import { FormSection, TextInput, SelectInput } from './components';
 import { useCoupangForm } from './hooks/useCoupangForm';
@@ -336,7 +337,7 @@ export default function CoupangApplicationForm() {
         <div className="container mx-auto px-4">
           <div className="flex flex-col md:flex-row justify-around items-center text-center md:text-left text-xs mb-3 space-y-2 md:space-y-0">
             <a href="https://pmagent.jp/" className="text-white hover:underline">運営会社について</a>
-            <a href="/privacy" className="text-white hover:underline">プライバシーポリシー</a>
+            <a href={`${BASE_PATH}/privacy`} className="text-white hover:underline">プライバシーポリシー</a>
           </div>
           <div className="text-center mt-3">
             <p className="text-xs">© 2025 株式会社PMAgent</p>

--- a/src/app/components/coupang-form/hooks/useCoupangForm.ts
+++ b/src/app/components/coupang-form/hooks/useCoupangForm.ts
@@ -1,3 +1,4 @@
+import { apiPath } from '@/lib/basePath';
 import { useState, useCallback, type FormEvent, type ChangeEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import type { CoupangFormData, CoupangFormErrors } from '../types';
@@ -90,7 +91,7 @@ export function useCoupangForm() {
         });
       }
 
-      const response = await fetch('/api/coupang/applicants', {
+      const response = await fetch(apiPath('/api/coupang/applicants'), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/app/components/coupang-form/hooks/useCoupangFormState.ts
+++ b/src/app/components/coupang-form/hooks/useCoupangFormState.ts
@@ -1,3 +1,4 @@
+import { apiPath } from '@/lib/basePath';
 import { useState, useCallback, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import type { CoupangFormData, CoupangFormErrors } from '../types';
@@ -200,7 +201,7 @@ export function useCoupangFormState() {
           form_name: 'coupang_rocketnow_application',
         });
 
-        const response = await fetch('/api/coupang/applicants', {
+        const response = await fetch(apiPath('/api/coupang/applicants'), {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/src/app/components/coupang-form/hooks/useCoupangStep1Options.ts
+++ b/src/app/components/coupang-form/hooks/useCoupangStep1Options.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { apiPath } from '@/lib/basePath';
 import { useEffect, useMemo, useState } from 'react';
 
 type SelectOption = {
@@ -56,7 +57,7 @@ export function useCoupangStep1Options() {
 
     (async () => {
       try {
-        const response = await fetch('/api/coupang/step1-options');
+        const response = await fetch(apiPath('/api/coupang/step1-options'));
         if (!response.ok) {
           return;
         }

--- a/src/app/components/coupang-form/hooks/useSeminarSlots.ts
+++ b/src/app/components/coupang-form/hooks/useSeminarSlots.ts
@@ -1,3 +1,4 @@
+import { apiPath } from '@/lib/basePath';
 import { useEffect, useState } from 'react';
 import type { SeminarSlot } from '../types';
 
@@ -14,7 +15,7 @@ export function useSeminarSlots() {
     const fetchSlots = async () => {
       try {
         setIsLoading(true);
-        const response = await fetch('/api/coupang/seminar-slots');
+        const response = await fetch(apiPath('/api/coupang/seminar-slots'));
 
         if (!response.ok) {
           const errorData = await response.json();

--- a/src/app/coupang/applicants/new/page.tsx
+++ b/src/app/coupang/applicants/new/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { BASE_PATH } from '@/lib/basePath';
 import { useEffect } from "react";
 import BookingEmbed from "@/app/components/BookingEmbed";
 
@@ -50,7 +51,7 @@ export default function CoupangApplicationComplete() {
         <div className="container mx-auto px-4">
           <div className="flex flex-col md:flex-row justify-around items-center text-center md:text-left text-xs mb-3 space-y-2 md:space-y-0">
             <a href="https://pmagent.jp/" className="text-white hover:underline">運営会社について</a>
-            <a href="/privacy" className="text-white hover:underline">プライバシーポリシー</a>
+            <a href={`${BASE_PATH}/privacy`} className="text-white hover:underline">プライバシーポリシー</a>
           </div>
           <div className="text-center mt-3">
             <p className="text-xs">© 2025 株式会社PMAgent</p>

--- a/src/app/coupang/page.tsx
+++ b/src/app/coupang/page.tsx
@@ -1,3 +1,4 @@
+import { BASE_PATH } from '@/lib/basePath';
 import Image from 'next/image';
 import CoupangStepForm from '@/app/components/coupang-form/CoupangStepForm';
 
@@ -34,7 +35,7 @@ export default function CoupangPage() {
             <div className="container mx-auto px-4">
               <div className="flex flex-col md:flex-row justify-around items-center text-center md:text-left text-xs mb-3 space-y-2 md:space-y-0">
                 <a href="https://pmagent.jp/" className="text-white hover:underline">運営会社について</a>
-                <a href="/privacy" className="text-white hover:underline">プライバシーポリシー</a>
+                <a href={`${BASE_PATH}/privacy`} className="text-white hover:underline">プライバシーポリシー</a>
               </div>
               <div className="text-center mt-3">
                 <p className="text-xs">© 2025 株式会社PMAgent</p>

--- a/src/app/mechanic/applicants/new/page.tsx
+++ b/src/app/mechanic/applicants/new/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { apiPath } from '@/lib/basePath';
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
@@ -42,7 +43,7 @@ export default function MechanicApplicationComplete() {
   useEffect(() => {
     const fetchJobs = async () => {
       try {
-        const response = await fetch('/api/jobs/random?categoryId=3&count=3');
+        const response = await fetch(apiPath('/api/jobs/random?categoryId=3&count=3'));
         if (!response.ok) {
           console.error('Failed to fetch jobs');
           setIsLoadingJobs(false);

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,3 +1,4 @@
+import { BASE_PATH } from '@/lib/basePath';
 import Image from "next/image";
 
 export default function PrivacyPolicy() {
@@ -120,7 +121,7 @@ export default function PrivacyPolicy() {
           </div>
           <div className="flex flex-col md:flex-row justify-around items-center text-center md:text-left text-xs mb-3 space-y-2 md:space-y-0">
             <a href="https://pmagent.jp/" className="text-white hover:underline">運営会社について</a>
-            <a href="/privacy" className="text-white hover:underline">プライバシーポリシー</a>
+            <a href={`${BASE_PATH}/privacy`} className="text-white hover:underline">プライバシーポリシー</a>
           </div>
           <div className="text-center mt-3">
             <p className="text-xs">© 2025 株式会社PMAgent</p>

--- a/src/app/taxi/applicants/new/page.tsx
+++ b/src/app/taxi/applicants/new/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../../applicants/new/page';

--- a/src/app/taxi/page.tsx
+++ b/src/app/taxi/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../page';

--- a/src/lib/basePath.ts
+++ b/src/lib/basePath.ts
@@ -1,0 +1,12 @@
+/**
+ * マルチゾーン配信用のベースパス。
+ * ridejob.jp 配下に複製デプロイする際だけ環境変数 NEXT_PUBLIC_BASE_PATH=/entry を設定する。
+ * 既存の ridejob.pmagent.jp（単独ドメイン）デプロイでは未設定＝空のまま（挙動不変）。
+ */
+export const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
+/**
+ * 内部API等の絶対パスにベースパスを前置する。
+ * Next.js の basePath は fetch の絶対パス（/api/...）を自動補完しないため、クライアントからのAPI呼び出しはこれを通す。
+ */
+export const apiPath = (p: string): string => `${BASE_PATH}${p}`;


### PR DESCRIPTION
## 目的
ridejob.pmagent.jp の応募フォームを **ridejob.jp/entry 配下**にもマルチゾーン配信し、求人(ridejob.jp/job)→応募 を**同一ドメイン**化して計測の分断（クロスドメインCookie・FBピクセル分断）を解消する。方式は既存の `/media`(newmedia) と同じ。

## 変更
- `next.config.ts`: `basePath` を `process.env.NEXT_PUBLIC_BASE_PATH` から取得（未設定なら無効＝従来通り）
- `src/lib/basePath.ts`: `BASE_PATH` / `apiPath()` 追加
- クライアントの `fetch('/api/...')` 13箇所を `apiPath()` でラップ（basePathはfetch絶対パスを補完しないため）
- `/taxi` ルート追加（タクシーLPを `/entry/taxi` にも公開・既存 `/` 維持）
- 生 `<a href="/privacy">` 5箇所を `BASE_PATH` 前置に修正（`<Link>`/`router.push` は basePath 自動対応）

## 互換性
同一リポジトリが **pmagent.jp にもデプロイされる**ため basePath は **env 条件付き**。pmagent.jp 側は env 未設定のまま＝**挙動完全不変**。

## デプロイ（要・別途）
- ridejob.jp/entry 用 deployment に **ビルド時 env `NEXT_PUBLIC_BASE_PATH=/entry`**（＋ Lark/Gmail/SMS/Meta 等の既存 env を同一設定）
- メインゾーン(jobmadley/Vercel設定)に `/entry/*` → 当 deployment の rewrite を追加（`/media` と同方式・`/entry/_next/*` 含む）
- pmagent.jp deployment は env 未設定のまま据え置き

## 検証
- `tsc --noEmit`: パス
- `NEXT_PUBLIC_BASE_PATH=/entry next build`: 成功（/taxi・/mechanic 等すべてビルド）
- 応募→Lark/メール/SMS の疎通はデプロイ後にテスト1件で要確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)