### PR TITLE
fix(entry): basePath配下で画像アセットが404になる不具合を修正

### DIFF
--- a/src/app/components/AppImage.tsx
+++ b/src/app/components/AppImage.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import NextImage, { type ImageProps } from 'next/image';
+
+import { assetPath } from '@/lib/basePath';
+
+/**
+ * next/image のラッパー。
+ *
+ * basePath 配下（NEXT_PUBLIC_BASE_PATH=/entry）では /public 画像が `${BASE_PATH}/...` で配信されるが、
+ * next/image は src（最適化URLの url パラメータ、SVG等の生src）に basePath を自動補完しない。
+ * そのため文字列の絶対パス src（/images/... 等）に BASE_PATH を前置する。
+ * リモートURL（http...）や StaticImport（importした画像オブジェクト）はそのまま渡す。
+ *
+ * BASE_PATH 未設定（pmagent.jp）では assetPath が素通しになるため挙動は不変。
+ */
+export default function Image(props: ImageProps) {
+  const { src } = props;
+  if (typeof src === 'string' && src.startsWith('/')) {
+    return <NextImage {...props} src={assetPath(src)} />;
+  }
+  return <NextImage {...props} />;
+}

--- a/src/app/components/ApplicationForm.tsx
+++ b/src/app/components/ApplicationForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Image from 'next/image';
+import Image from '@/app/components/AppImage';
 import { Suspense, useEffect, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
 

--- a/src/app/components/JobCard.tsx
+++ b/src/app/components/JobCard.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/image';
+import Image from '@/app/components/AppImage';
 import Link from 'next/link';
 import type { Job } from '@/lib/microcms';
 

--- a/src/app/components/application-form/components/BirthDateCard.tsx
+++ b/src/app/components/application-form/components/BirthDateCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Image from 'next/image';
+import Image from '@/app/components/AppImage';
 
 import FormCard from './FormCard';
 import FingerHint from './FingerHint';

--- a/src/app/components/application-form/components/FingerHint.tsx
+++ b/src/app/components/application-form/components/FingerHint.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Image from 'next/image';
+import Image from '@/app/components/AppImage';
 
 type FingerHintProps = {
   isVisible: boolean;

--- a/src/app/components/application-form/components/FormExitModal.tsx
+++ b/src/app/components/application-form/components/FormExitModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Image from 'next/image';
+import Image from '@/app/components/AppImage';
 import type { ReactNode } from 'react';
 
 type FormExitModalProps = {

--- a/src/app/components/application-form/components/MechanicQualificationCard.tsx
+++ b/src/app/components/application-form/components/MechanicQualificationCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Image from 'next/image';
+import Image from '@/app/components/AppImage';
 import FormCard from './FormCard';
 import StepProgressBar from './StepProgressBar';
 import type { FormErrors, FormOrigin, MechanicQualification } from '../types';

--- a/src/app/components/application-form/components/NameAndContactCard.tsx
+++ b/src/app/components/application-form/components/NameAndContactCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Image from 'next/image';
+import Image from '@/app/components/AppImage';
 
 import FormCard from './FormCard';
 import FingerHint from './FingerHint';

--- a/src/app/components/application-form/components/NameCard.tsx
+++ b/src/app/components/application-form/components/NameCard.tsx
@@ -3,7 +3,7 @@
 import { apiPath } from '@/lib/basePath';
 import { useEffect, useMemo, useState } from 'react';
 
-import Image from 'next/image';
+import Image from '@/app/components/AppImage';
 
 import FormCard from './FormCard';
 import FingerHint from './FingerHint';

--- a/src/app/components/application-form/components/NameInputCard.tsx
+++ b/src/app/components/application-form/components/NameInputCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Image from 'next/image';
+import Image from '@/app/components/AppImage';
 
 import FormCard from './FormCard';
 import FingerHint from './FingerHint';

--- a/src/app/components/application-form/components/PhoneNumberCard.tsx
+++ b/src/app/components/application-form/components/PhoneNumberCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Image from 'next/image';
+import Image from '@/app/components/AppImage';
 
 import FormCard from './FormCard';
 import FingerHint from './FingerHint';

--- a/src/app/components/application-form/hooks/useImagePreloader.ts
+++ b/src/app/components/application-form/hooks/useImagePreloader.ts
@@ -2,6 +2,8 @@
 
 import { useEffect, useRef } from 'react';
 
+import { assetPath } from '@/lib/basePath';
+
 type UseImagePreloaderParams = {
   images: string[];
   onComplete: () => void;
@@ -30,8 +32,11 @@ export function useImagePreloader({ images, onComplete, enable }: UseImagePreloa
 
     images.forEach((src) => {
       const img = document.createElement('img');
-      img.src = src;
+      // basePath 配下では /public 画像が `${BASE_PATH}/...` で配信されるため前置する。
+      img.src = src.startsWith('/') ? assetPath(src) : src;
       img.onload = handleLoad;
+      // 画像が見つからない場合もローディングが止まらないよう、エラーも「完了」扱いにする。
+      img.onerror = handleLoad;
     });
 
     const fallbackTimer = setTimeout(onComplete, 5000);

--- a/src/app/components/coupang-form/CoupangApplicationForm.legacy.tsx
+++ b/src/app/components/coupang-form/CoupangApplicationForm.legacy.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { BASE_PATH } from '@/lib/basePath';
-import Image from 'next/image';
+import Image from '@/app/components/AppImage';
 import { FormSection, TextInput, SelectInput } from './components';
 import { useCoupangForm } from './hooks/useCoupangForm';
 import {

--- a/src/app/components/coupang-form/CoupangApplicationForm.tsx
+++ b/src/app/components/coupang-form/CoupangApplicationForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { BASE_PATH } from '@/lib/basePath';
-import Image from 'next/image';
+import Image from '@/app/components/AppImage';
 import { FormSection, TextInput, SelectInput } from './components';
 import { useCoupangForm } from './hooks/useCoupangForm';
 import {

--- a/src/app/components/coupang-form/components/CoupangApplicationInfoCard.tsx
+++ b/src/app/components/coupang-form/components/CoupangApplicationInfoCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Image from 'next/image';
+import Image from '@/app/components/AppImage';
 import FormCard from '../../application-form/components/FormCard';
 import { SelectInput } from './SelectInput';
 import type { CoupangFormData, CoupangFormErrors, JobPosition, DesiredLocation } from '../types';

--- a/src/app/components/coupang-form/components/CoupangConditionCard.tsx
+++ b/src/app/components/coupang-form/components/CoupangConditionCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Image from 'next/image';
+import Image from '@/app/components/AppImage';
 import FormCard from '../../application-form/components/FormCard';
 import { TextInput } from './TextInput';
 import type { CoupangFormData, CoupangFormErrors } from '../types';

--- a/src/app/components/coupang-form/components/CoupangPersonalInfoCard.tsx
+++ b/src/app/components/coupang-form/components/CoupangPersonalInfoCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Image from 'next/image';
+import Image from '@/app/components/AppImage';
 import FormCard from '../../application-form/components/FormCard';
 import { TextInput } from './TextInput';
 import type { CoupangFormData, CoupangFormErrors } from '../types';

--- a/src/app/components/coupang-form/components/CoupangSeminarInfoCard.tsx
+++ b/src/app/components/coupang-form/components/CoupangSeminarInfoCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Image from 'next/image';
+import Image from '@/app/components/AppImage';
 import FormCard from '../../application-form/components/FormCard';
 import { SelectInput } from './SelectInput';
 import { TextInput } from './TextInput';

--- a/src/app/coupang/page.tsx
+++ b/src/app/coupang/page.tsx
@@ -1,5 +1,5 @@
 import { BASE_PATH } from '@/lib/basePath';
-import Image from 'next/image';
+import Image from '@/app/components/AppImage';
 import CoupangStepForm from '@/app/components/coupang-form/CoupangStepForm';
 
 export default function CoupangPage() {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,7 +26,8 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
-  background-image: url('/images/mobile-bg.png');
+  /* basePath 配下対応: URL は layout.tsx で CSS 変数として注入（既定はルート配信） */
+  background-image: var(--app-bg-mobile, url('/images/mobile-bg.png'));
   background-size: 115% auto;
   background-position: center;
   background-repeat: no-repeat;
@@ -43,6 +44,6 @@ body {
 
 @media (min-width: 768px) {
   body {
-    background-image: url('/images/pc-bg.png');
+    background-image: var(--app-bg-pc, url('/images/pc-bg.png'));
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import { Geist, Geist_Mono } from "next/font/google";
 import Script from "next/script";
 import "./globals.css";
 
+import { BASE_PATH } from "@/lib/basePath";
+
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
@@ -17,7 +19,7 @@ export const metadata: Metadata = {
   title: "タクシー運転手の転職ならライドジョブ｜応募フォーム",
   description: "未経験でもわかるドライバー業界の魅力発掘メディア。\nライドジョブは仕事のやりがいやリアルな声、キャリアの可能性など、ドライバー業界の魅力を発見・共有する情報発信プラットフォームです。経験者の声や成功事例、未経験からのキャリアスタートのヒントなど、幅広い情報をお届けします。",
   icons: {
-    icon: "/favicon.png",
+    icon: `${BASE_PATH}/favicon.png`,
   },
 };
 
@@ -28,6 +30,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja">
+      <head>
+        {/* basePath 配下では /public 画像が `${BASE_PATH}/...` で配信されるため、背景画像URLを注入する */}
+        <style
+          dangerouslySetInnerHTML={{
+            __html: `:root{--app-bg-mobile:url('${BASE_PATH}/images/mobile-bg.png');--app-bg-pc:url('${BASE_PATH}/images/pc-bg.png');}`,
+          }}
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/src/lib/basePath.ts
+++ b/src/lib/basePath.ts
@@ -10,3 +10,10 @@ export const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
  * Next.js の basePath は fetch の絶対パス（/api/...）を自動補完しないため、クライアントからのAPI呼び出しはこれを通す。
  */
 export const apiPath = (p: string): string => `${BASE_PATH}${p}`;
+
+/**
+ * /public 配下の静的アセット（/images/... 等）の絶対パスにベースパスを前置する。
+ * basePath 配下では public は `${BASE_PATH}/...` で配信されるが、next/image の url パラメータや
+ * 生の img.src・CSS url() には basePath が自動補完されないため、これを通す。
+ */
+export const assetPath = (p: string): string => `${BASE_PATH}${p}`;


### PR DESCRIPTION
## 背景
PR #9 で `/entry`(basePath=/entry) 複製配信を導入したが、**画像アセットが basePath 無しで参照され 404** になり、フォームがローディングで止まる／画像・背景が表示されない不具合があった。

実証（本番 ridejob.jp 経由）:
```
/entry/_next/image?url=%2Fimages%2FSTEP1.webp        → 404
/entry/_next/image?url=%2Fentry%2Fimages%2FSTEP1.webp → 200
ridejob.jp/images/ride_logo.svg        → 404
ridejob.jp/entry/images/ride_logo.svg  → 200
```

## 原因
basePath 配下では /public 画像が `${BASE_PATH}/...` で配信されるが、以下に basePath が自動補完されない:
- `next/image` の optimizer `url=` パラメータ（webp等）
- `next/image` の SVG 等「非最適化」画像の生 src
- `useImagePreloader` の生 `img.src`
- `globals.css` の `url('/images/...')`

PR #9 は `fetch`/`<a>`/`<Link>` は basePath 対応済みだったが、**画像アセットの対応が漏れていた**。

## 修正
- `next/image` ラッパー `AppImage` を追加し、文字列の絶対パス src に `BASE_PATH` を前置（リモートURL/StaticImportは素通し）
- 全コンポーネントの `next/image` import をラッパーに差し替え（**JSXは無変更**）
- `useImagePreloader`: 生 `img.src` に `BASE_PATH` 前置＋`onerror` も完了扱い（無限ローディング防止）
- `globals.css` 背景画像を CSS 変数化し `layout.tsx` で `BASE_PATH` 付きで注入
- favicon も `BASE_PATH` 対応
- `lib/basePath`: `assetPath()` を追加

## 互換性
`pmagent.jp`（`NEXT_PUBLIC_BASE_PATH` 未設定）では `assetPath` が素通しのため**挙動不変**。

## 検証
- Vercel プレビュー（ridejob-entry / basePath=/entry）でビルド＆画像200を確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)