### PR TITLE
fix(entry): /entry でローディングが終わらない不具合を修正

### DIFF
--- a/src/app/components/application-form/hooks/useHiraganaConverter.ts
+++ b/src/app/components/application-form/hooks/useHiraganaConverter.ts
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useRef } from 'react';
 
+import { assetPath } from '@/lib/basePath';
+
 type KuroshiroInstance = import('kuroshiro').default | null;
 
 export function useHiraganaConverter() {
@@ -13,7 +15,7 @@ export function useHiraganaConverter() {
         const Kuroshiro = (await import('kuroshiro')).default;
         const KuromojiAnalyzer = (await import('kuroshiro-analyzer-kuromoji')).default;
         const kuroshiro = new Kuroshiro();
-        await kuroshiro.init(new KuromojiAnalyzer({ dictPath: '/dict' }));
+        await kuroshiro.init(new KuromojiAnalyzer({ dictPath: assetPath('/dict') }));
         kuroshiroRef.current = kuroshiro;
       } catch (error) {
         console.error('Failed to initialize Kuroshiro:', error);

--- a/src/app/components/application-form/hooks/useImagePreloader.ts
+++ b/src/app/components/application-form/hooks/useImagePreloader.ts
@@ -11,40 +11,44 @@ type UseImagePreloaderParams = {
 };
 
 export function useImagePreloader({ images, onComplete, enable }: UseImagePreloaderParams) {
-  const loadedCount = useRef(0);
-  const totalImages = useRef(images.length);
+  // onComplete はインラインで毎レンダー変わるため ref 経由で参照し、effect の依存に含めない。
+  // （依存に含めると親の再レンダーごとに effect が再実行され、完了タイマーが毎回クリアされてローディングが終わらない）
+  const onCompleteRef = useRef(onComplete);
+  onCompleteRef.current = onComplete;
+  const doneRef = useRef(false);
 
   useEffect(() => {
     if (!enable) return;
+    if (doneRef.current) return;
+
+    const complete = () => {
+      if (doneRef.current) return;
+      doneRef.current = true;
+      onCompleteRef.current();
+    };
+
     if (images.length === 0) {
-      onComplete();
+      complete();
       return;
     }
 
-    const timers: NodeJS.Timeout[] = [];
-
-    const handleLoad = () => {
-      loadedCount.current += 1;
-      if (loadedCount.current >= totalImages.current) {
-        timers.push(setTimeout(onComplete, 500));
-      }
+    let loaded = 0;
+    const handleOne = () => {
+      loaded += 1;
+      if (loaded >= images.length) complete();
     };
 
     images.forEach((src) => {
       const img = document.createElement('img');
+      img.onload = handleOne;
+      // 画像が見つからない場合もローディングが止まらないよう、エラーも「完了」扱いにする。
+      img.onerror = handleOne;
       // basePath 配下では /public 画像が `${BASE_PATH}/...` で配信されるため前置する。
       img.src = src.startsWith('/') ? assetPath(src) : src;
-      img.onload = handleLoad;
-      // 画像が見つからない場合もローディングが止まらないよう、エラーも「完了」扱いにする。
-      img.onerror = handleLoad;
     });
 
-    const fallbackTimer = setTimeout(onComplete, 5000);
-    timers.push(fallbackTimer);
-
-    return () => {
-      timers.forEach((timer) => clearTimeout(timer));
-    };
-  }, [enable, images, onComplete]);
+    // 何があっても一定時間で必ずローディングを終了させる安全網。
+    const fallbackTimer = setTimeout(complete, 5000);
+    return () => clearTimeout(fallbackTimer);
+  }, [enable, images]);
 }
-

--- a/src/lib/locationClient.ts
+++ b/src/lib/locationClient.ts
@@ -1,3 +1,5 @@
+import { apiPath } from '@/lib/basePath';
+
 const prefectureCache = new Map<string, string>();
 const municipalityCache = new Map<string, string>();
 
@@ -14,7 +16,7 @@ export async function fetchPrefectureName(prefectureId: string): Promise<string>
     return prefectureCache.get(prefectureId) ?? '';
   }
 
-  const data = await fetchJSON<{ contents: { id: string; region: string }[] }>('/api/location/prefectures');
+  const data = await fetchJSON<{ contents: { id: string; region: string }[] }>(apiPath('/api/location/prefectures'));
   data.contents.forEach((item) => {
     prefectureCache.set(item.id, item.region);
   });
@@ -27,7 +29,7 @@ export async function fetchMunicipalityName(municipalityId: string): Promise<str
     return municipalityCache.get(municipalityId) ?? '';
   }
 
-  const data = await fetchJSON<{ contents: { id: string; name: string }[] }>(`/api/location/municipalities?municipalityId=${municipalityId}`);
+  const data = await fetchJSON<{ contents: { id: string; name: string }[] }>(apiPath(`/api/location/municipalities?municipalityId=${municipalityId}`));
   data.contents.forEach((item) => {
     municipalityCache.set(item.id, item.name);
   });


### PR DESCRIPTION
## 症状
basePath=/entry の Vercel 配信（ridejob.jp/entry, ridejob-entry.vercel.app/entry）で、ローディング画面から進まない。ローカル(dev/本番ビルド)・既存 pmagent.jp(basePathなし) では正常。

## 原因
1. `useImagePreloader` の `onComplete` がインライン関数で毎レンダー変化 → effect 依存に含まれ、親の再レンダーごとに effect 再実行 → 完了/5秒フォールバックのタイマーが毎回 clearTimeout され、ローディングが永久に終わらない。ローカルは再レンダーが落ち着くため完了するが、Vercel 配信では完了しなかった。
2. `useHiraganaConverter` の kuromoji `dictPath: '/dict'` が basePath 非対応 → /entry で 404。
3. `locationClient` の `/api/location/*` が `apiPath` 未適用（submit時）。

## 修正
- preloader: `onComplete` を ref 化し依存から除外、完了は1回だけ(`doneRef`)。5秒フォールバックも再レンダーでリセットされず確実に終了。
- `dictPath: assetPath('/dict')`。
- locationClient を `apiPath` でラップ。

## 互換性
pmagent.jp(BASE_PATH未設定)では `assetPath`/`apiPath` が素通しのため挙動不変。

🤖 Generated with [Claude Code](https://claude.com/claude-code)