### PR TITLE
fix(entry): 完了ページ等の next/image import 漏れを修正

### DIFF
--- a/src/app/applicants/new/page.tsx
+++ b/src/app/applicants/new/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { apiPath } from '@/lib/basePath';
-import Image from "next/image";
+import Image from "@/app/components/AppImage";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import BookingEmbed from "@/app/components/BookingEmbed";

--- a/src/app/bus/applicants/new/page.tsx
+++ b/src/app/bus/applicants/new/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { apiPath } from '@/lib/basePath';
-import Image from "next/image";
+import Image from "@/app/components/AppImage";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import BookingEmbed from "@/app/components/BookingEmbed";

--- a/src/app/mechanic/applicants/new/page.tsx
+++ b/src/app/mechanic/applicants/new/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { apiPath } from '@/lib/basePath';
-import Image from "next/image";
+import Image from "@/app/components/AppImage";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import BookingEmbed from "@/app/components/BookingEmbed";

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,5 +1,5 @@
 import { BASE_PATH } from '@/lib/basePath';
-import Image from "next/image";
+import Image from "@/app/components/AppImage";
 
 export default function PrivacyPolicy() {
   return (


### PR DESCRIPTION
## 背景
PR #10 で `next/image` を AppImage ラッパーに差し替えた際、置換対象がシングルクォート import のみだったため、**ダブルクォート** `import Image from "next/image"` の以下ファイルが漏れていた。結果 `/entry/applicants/new`（サンクスページ）等で画像が basePath 無し参照→404。

## 修正
以下の import をラッパーに差し替え（JSXは無変更）:
- `applicants/new/page.tsx`
- `bus/applicants/new/page.tsx`
- `mechanic/applicants/new/page.tsx`
- `privacy/page.tsx`

## 検証
- 残り直接 import は AppImage.tsx のみ、生 `<img>`・生 img.src 無しを確認
- プレビュー(ridejob-entry/basePath=/entry)で `/entry/applicants/new` の画像200を確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)