### PR TITLE
feat(BP-LP): 説明会申込を Lark Base「IDOM_新卒2027」へ登録

### DIFF
--- a/src/app/api/entry-bp/route.ts
+++ b/src/app/api/entry-bp/route.ts
@@ -1,8 +1,13 @@
 import { NextResponse } from "next/server";
+import { createBaseRecord, isLarkBaseConfigured } from "@/lib/larkBase";
 
 // 2027新卒 鈑金塗装職LP（/gulliver/newgraduate → 本番は /entry/gulliver/newgraduate）の
-// 会社説明会お申し込み受付。当リポジトリの applicants と同じく Lark Webhook へ通知する軽量リード窓口。
-// 専用チャンネル LARK_WEBHOOK_URL_GULLIVER_BP を優先し、無ければ MECHANIC → 既定 にフォールバック。
+// 会社説明会お申し込み受付。
+//   1) Lark Base(Bitable)「IDOM_新卒2027」テーブルへレコード登録（永続化／主処理。失敗時はエラー）
+//   2) Lark チャットへ Webhook 通知（即時把握用／ベストエフォート。失敗しても申込は成功扱い）
+
+// 投入先テーブル。既定は IDOM_新卒2027（tblfCA6cyDp8ZGao）。
+const TABLE_ID = process.env.LARK_BASE_TABLE_ID_GULLIVER_BP || "tblfCA6cyDp8ZGao";
 
 const isValidEmail = (value: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
 const cap = (s: string, n: number) => (s.length > n ? s.slice(0, n) : s);
@@ -33,6 +38,33 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: errors.join(" ") }, { status: 400 });
     }
 
+    // --- 1) Lark Base 登録（主処理）---
+    // 認証情報が未設定（本番 env 未投入など）の場合はスキップし、チャット通知だけ行う。
+    // これによりフォーム自体は止まらず、env 投入後に自動で Base 登録が有効化される。
+    if (isLarkBaseConfigured()) {
+      try {
+        await createBaseRecord(TABLE_ID, {
+          求職者名: name,
+          メールアドレス: email,
+          電話番号: tel || undefined,
+          ステータス: "リード",
+          登録職種: "板金/塗装技能士",
+          応募日: Date.now(),
+          クリエイティブ: "BP_2027新卒LP (/entry/gulliver/newgraduate)",
+          対応履歴メモ: area ? `希望勤務エリア: ${area}` : undefined,
+        });
+      } catch (e) {
+        console.error("[entry-bp] Lark Base 登録失敗:", e);
+        return NextResponse.json(
+          { error: "送信に失敗しました。時間をおいて再度お試しください。" },
+          { status: 502 }
+        );
+      }
+    } else {
+      console.warn("[entry-bp] Lark Base 認証情報が未設定のため Base 登録をスキップ（チャット通知のみ）");
+    }
+
+    // --- 2) Lark チャット通知（ベストエフォート）---
     const isProd = process.env.NODE_ENV === "production";
     const webhookUrl =
       process.env.LARK_WEBHOOK_URL_GULLIVER_BP_PROD ||
@@ -41,46 +73,33 @@ export async function POST(req: Request) {
       process.env.LARK_WEBHOOK_URL_MECHANIC ||
       process.env.LARK_WEBHOOK_URL;
 
-    if (!webhookUrl) {
-      return NextResponse.json({ error: "サーバー設定が不足しています。(WEBHOOK)" }, { status: 500 });
-    }
+    if (webhookUrl) {
+      const textLines: string[] = [
+        "【2027新卒 鈑金塗装職LP / Gulliver】会社説明会のお申し込みが届きました",
+        `お名前: ${name}`,
+        `メール: ${email}`,
+        tel ? `電話: ${tel}` : undefined,
+        area ? `希望エリア: ${area}` : undefined,
+        "経路: /entry/gulliver/newgraduate (BP / 2027新卒)",
+      ].filter((line): line is string => typeof line === "string");
 
-    const textLines: string[] = [
-      "【2027新卒 鈑金塗装職LP / Gulliver】会社説明会のお申し込みが届きました",
-      `お名前: ${name}`,
-      `メール: ${email}`,
-      tel ? `電話: ${tel}` : undefined,
-      area ? `希望エリア: ${area}` : undefined,
-      "経路: /entry/gulliver/newgraduate (BP / 2027新卒)",
-    ].filter((line): line is string => typeof line === "string");
+      const payload = { msg_type: "text", content: { text: textLines.join("\n") } };
 
-    const payload = { msg_type: "text", content: { text: textLines.join("\n") } };
-
-    let larkRes: Response;
-    try {
-      larkRes = await fetch(webhookUrl, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-        signal: AbortSignal.timeout(5000),
-      });
-    } catch {
-      return NextResponse.json(
-        { error: "送信に失敗しました。時間をおいて再度お試しください。" },
-        { status: 502 }
-      );
-    }
-
-    const larkData = await larkRes.json().catch(() => ({} as { code?: number }));
-
-    if (
-      !larkRes.ok ||
-      (larkData && typeof larkData.code !== "undefined" && larkData.code !== 0)
-    ) {
-      return NextResponse.json(
-        { error: "送信に失敗しました。時間をおいて再度お試しください。" },
-        { status: 502 }
-      );
+      try {
+        const larkRes = await fetch(webhookUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+          signal: AbortSignal.timeout(5000),
+        });
+        const larkData = await larkRes.json().catch(() => ({} as { code?: number }));
+        if (!larkRes.ok || (larkData && typeof larkData.code !== "undefined" && larkData.code !== 0)) {
+          // Base には登録済みなので、通知失敗は記録のみで握りつぶす。
+          console.error("[entry-bp] Lark チャット通知失敗:", larkData);
+        }
+      } catch (e) {
+        console.error("[entry-bp] Lark チャット通知エラー:", e);
+      }
     }
 
     return NextResponse.json({ ok: true });

--- a/src/lib/larkBase.ts
+++ b/src/lib/larkBase.ts
@@ -1,0 +1,114 @@
+// Lark Bitable(Base)へレコードを作成する軽量クライアント。
+// tenant_access_token を取得 →（プロセス内キャッシュ）→ 指定テーブルへ records 作成。
+// 認証は MECHANIC アプリ（APP_ID_MECHANIC / APP_SECRET_MECHANIC / APP_TOKEN_MECHANIC）。
+// Webhook 方式と異なり、フィールドを直接指定して書けるのが利点。
+
+interface LarkBaseConfig {
+  domain: string;
+  appId: string;
+  appSecret: string;
+  appToken: string;
+}
+
+// Bitable のフィールド値。Text/Select=string、MultiSelect=string[]、Number/DateTime=number、Checkbox=boolean。
+export type LarkFieldValue = string | number | boolean | string[];
+
+interface TokenCache {
+  token: string;
+  expiresAt: number; // epoch ms
+}
+
+let tokenCache: TokenCache | null = null;
+
+function readConfig(): LarkBaseConfig | null {
+  const domain = (process.env.LARK_DOMAIN_MECHANIC || "https://open.larksuite.com").replace(/\/+$/, "");
+  const appId = process.env.APP_ID_MECHANIC;
+  const appSecret = process.env.APP_SECRET_MECHANIC;
+  const appToken = process.env.APP_TOKEN_MECHANIC;
+  if (!appId || !appSecret || !appToken) return null;
+  return { domain, appId, appSecret, appToken };
+}
+
+// 認証情報が揃っているか。未設定なら呼び出し側で Base 登録をスキップできる
+// （本番に env がまだ無い状態でデプロイされてもフォームを止めないため）。
+export function isLarkBaseConfigured(): boolean {
+  return readConfig() !== null;
+}
+
+async function fetchTenantAccessToken(cfg: LarkBaseConfig): Promise<string> {
+  const now = Date.now();
+  // 期限の30秒前までは使い回す。
+  if (tokenCache && tokenCache.expiresAt > now + 30_000) return tokenCache.token;
+
+  const res = await fetch(`${cfg.domain}/open-apis/auth/v3/tenant_access_token/internal`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify({ app_id: cfg.appId, app_secret: cfg.appSecret }),
+    signal: AbortSignal.timeout(5000),
+  });
+  const data = (await res.json().catch(() => ({}))) as {
+    code?: number;
+    tenant_access_token?: string;
+    expire?: number; // 秒
+    msg?: string;
+  };
+  if (!res.ok || data.code !== 0 || !data.tenant_access_token) {
+    throw new Error(`tenant_access_token 取得失敗: code=${data.code} msg=${data.msg}`);
+  }
+  tokenCache = {
+    token: data.tenant_access_token,
+    expiresAt: now + (data.expire ?? 7200) * 1000,
+  };
+  return tokenCache.token;
+}
+
+async function postRecord(
+  cfg: LarkBaseConfig,
+  token: string,
+  tableId: string,
+  fields: Record<string, LarkFieldValue>
+): Promise<{ code?: number; msg?: string; ok: boolean }> {
+  const url = `${cfg.domain}/open-apis/bitable/v1/apps/${cfg.appToken}/tables/${tableId}/records`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify({ fields }),
+    signal: AbortSignal.timeout(5000),
+  });
+  const data = (await res.json().catch(() => ({}))) as { code?: number; msg?: string };
+  return { code: data.code, msg: data.msg, ok: res.ok };
+}
+
+// 指定テーブルにレコードを1件作成する。失敗時は throw。
+// undefined / 空文字のフィールドは送信しない。
+export async function createBaseRecord(
+  tableId: string,
+  fields: Record<string, LarkFieldValue | undefined>
+): Promise<void> {
+  const cfg = readConfig();
+  if (!cfg) throw new Error("Lark Base 認証情報（APP_ID_MECHANIC / APP_SECRET_MECHANIC / APP_TOKEN_MECHANIC）が未設定です。");
+
+  const cleaned: Record<string, LarkFieldValue> = {};
+  for (const [k, v] of Object.entries(fields)) {
+    if (v !== undefined && v !== "") cleaned[k] = v;
+  }
+
+  let token = await fetchTenantAccessToken(cfg);
+  let result = await postRecord(cfg, token, tableId, cleaned);
+
+  // トークン失効（99991661/99991663 など）時はキャッシュを捨てて1度だけ再試行。
+  if (!result.ok || (typeof result.code !== "undefined" && result.code !== 0)) {
+    if (result.code === 99991661 || result.code === 99991663) {
+      tokenCache = null;
+      token = await fetchTenantAccessToken(cfg);
+      result = await postRecord(cfg, token, tableId, cleaned);
+    }
+  }
+
+  if (!result.ok || (typeof result.code !== "undefined" && result.code !== 0)) {
+    throw new Error(`Base レコード作成失敗: code=${result.code} msg=${result.msg}`);
+  }
+}


### PR DESCRIPTION
## 概要
Gulliver 2027新卒 鈑金塗装職LP（`/entry/gulliver/newgraduate`）の会社説明会申込を、**Lark Base(Bitable) のテーブル「IDOM_新卒2027」(`tblfCA6cyDp8ZGao`) へレコード登録**するように変更。従来の Lark チャット Webhook 通知はベストエフォートで併用する。

## 変更内容
- `src/lib/larkBase.ts` 追加: Bitable Open API クライアント。`tenant_access_token` 取得（プロセス内キャッシュ＋失効時1回再試行）→ records 作成。認証は MECHANIC アプリ。
- `src/app/api/entry-bp/route.ts`:
  - **Base 登録を主処理化**（失敗時は 502）。
  - **認証情報が未設定なら Base 登録をスキップし、チャット通知のみ**でフォームを止めない（本番 env 未投入時の安全装置。env 投入後に自動で有効化）。
  - チャット通知はベストエフォート（失敗してもログのみ・申込は成功扱い）。

### フィールドマッピング
| Base | 値 |
|---|---|
| 求職者名 | name |
| メールアドレス | email |
| 電話番号 | tel |
| ステータス | リード |
| 登録職種 | 板金/塗装技能士 |
| 応募日 | 送信日時 |
| クリエイティブ | BP_2027新卒LP (/entry/gulliver/newgraduate) |
| 対応履歴メモ | 希望勤務エリア: {area} |

## ⚠️ 本番デプロイ前に必要な環境変数（Vercel）
```
APP_ID_MECHANIC
APP_SECRET_MECHANIC
LARK_DOMAIN_MECHANIC=https://open.larksuite.com
APP_TOKEN_MECHANIC=As9mbdBVwau6KNsqYLqjUPJspCf
LARK_BASE_TABLE_ID_GULLIVER_BP=tblfCA6cyDp8ZGao
```
未設定でもフォームは動作（チャット通知のみ）。設定後に Base 登録が有効化される。

## 検証
- `tsc --noEmit` 通過
- dev サーバーで実 POST → Base にレコード作成を確認（全フィールド正しくマッピング）→ テストレコード削除済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)