### PR TITLE
feat(meta): 応募フォームを直ピクセル+CAPI化（送信時Lead）

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ npm install
 LARK_WEBHOOK_URL=your_lark_webhook_url_here
 ```
 
+#### Meta計測（直ピクセル + Conversions API）
+```bash
+NEXT_PUBLIC_META_PIXEL_ID=1945615652686189    # 統合ピクセル「タクシー」（公開値・ページに埋め込まれる）
+META_CAPI_ACCESS_TOKEN=your_capi_access_token # Events Manager > 設定で発行・サーバー専用・秘匿。未設定だとCAPIはスキップ
+META_TEST_EVENT_CODE=                          # 検証時のみ設定（Events Manager > テストイベント）。本番は空
+```
+
 #### Coupangフォーム用設定
 ```bash
 # Lark Webhook URLs（開発環境）

--- a/src/app/api/applicants/route.ts
+++ b/src/app/api/applicants/route.ts
@@ -9,6 +9,7 @@ import {
 } from '@/lib/email/send-application-confirmation';
 import { sendApplicationSms } from '@/lib/sms/send-application-sms';
 import { resolveAdImageUrl, isLikelyAdId } from '@/lib/meta/resolveAdImage';
+import { sendMetaCapiLead } from '@/lib/meta/capi';
 
 // Types for submission payload
 type ExperimentInfo = {
@@ -47,6 +48,7 @@ type ApplicantSubmission = ApplicantFormData & {
   utmParams?: UTMParams;
   experiment?: ExperimentInfo;
   formOrigin?: 'coupang' | 'default' | 'bus' | 'mechanic' | 'mechanic_newgrad';
+  metaEventId?: string;
 };
 
 // UTM parameters to media name mapping function
@@ -419,6 +421,24 @@ ${additionalFields ? `${additionalFields}\n` : ''}電話番号: ${formData.phone
               console.log('Application SMS skipped/failed:', { reason: r.reason, error: r.error, channel, media });
             }
           })()
+        );
+      }
+
+      // Meta Conversions API（Lead）— 非致命。eventId が無ければスキップ
+      if (typeof submissionData.metaEventId === 'string' && submissionData.metaEventId) {
+        const capiUserAgent = request.headers.get('user-agent') || '';
+        const capiClientIp = (request.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() || '';
+        tasks.push(
+          sendMetaCapiLead({
+            eventId: submissionData.metaEventId,
+            eventSourceUrl: referer,
+            email: formData.email,
+            phone: formData.phoneNumber,
+            fbp: request.cookies.get('_fbp')?.value,
+            fbc: request.cookies.get('_fbc')?.value,
+            clientIpAddress: capiClientIp || undefined,
+            clientUserAgent: capiUserAgent || undefined,
+          }).then(() => {})
         );
       }
 

--- a/src/app/components/application-form/hooks/useApplicationFormState.ts
+++ b/src/app/components/application-form/hooks/useApplicationFormState.ts
@@ -9,6 +9,7 @@ import { useHiraganaConverter } from './useHiraganaConverter';
 import { useFormExitGuard } from './useFormExitGuard';
 import { useImagePreloader } from './useImagePreloader';
 import { trackEvent } from '../utils/trackEvent';
+import { genEventId, trackMeta } from '@/lib/meta/pixel';
 import { isValidEmail, isValidPhoneNumber, validateBirthDateCard, validateCard2, validateDesiredIncome, validateFinalStep, validateJobTiming, validateMechanicQualification, validateNameFields } from '../utils/validators';
 import { fetchJobCount, type JobCountParams } from '../utils/fetchJobCount';
 import { notifyInvalidPhoneNumber } from '../utils/notifyInvalidPhoneNumber';
@@ -616,6 +617,7 @@ export function useApplicationFormState({ showLoadingScreen, imagesToPreload, va
           }
         }
 
+        const metaEventId = genEventId();
         const body = {
           ...formData,
           birthDate: birthDateString,
@@ -625,6 +627,7 @@ export function useApplicationFormState({ showLoadingScreen, imagesToPreload, va
           utmParams,
           experiment: { name: 'people_image', variant },
           formOrigin,
+          metaEventId,
         } as Record<string, unknown>;
 
         const response = await fetch(apiPath('/api/applicants'), {
@@ -642,6 +645,9 @@ export function useApplicationFormState({ showLoadingScreen, imagesToPreload, va
 
         await response.json();
         setIsFormDirty(false);
+
+        // 送信成功時に Meta Lead を発火（サーバーCAPIと同一 eventId で重複排除）
+        trackMeta('Lead', { value: 0, currency: 'JPY' }, metaEventId);
 
         // 都道府県IDとお名前をlocalStorageに保存（サンクスページで求人表示・パーソナライズ用）
         if (typeof window !== 'undefined') {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,6 +28,8 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const metaPixelId = process.env.NEXT_PUBLIC_META_PIXEL_ID;
+
   return (
     <html lang="ja">
       <head>
@@ -37,6 +39,16 @@ export default function RootLayout({
             __html: `:root{--app-bg-mobile:url('${BASE_PATH}/images/mobile-bg.png');--app-bg-pc:url('${BASE_PATH}/images/pc-bg.png');}`,
           }}
         />
+
+        {/* Meta Pixel */}
+        {metaPixelId && (
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `!function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,document,'script','https://connect.facebook.net/en_US/fbevents.js');fbq('init','${metaPixelId}');fbq('track','PageView');`,
+            }}
+          />
+        )}
+        {/* End Meta Pixel */}
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
@@ -60,6 +72,22 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             style={{ display: 'none', visibility: 'hidden' }}
           />
         </noscript>
+
+        {/* Meta Pixel (noscript) */}
+        {metaPixelId && (
+          <noscript>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              height="1"
+              width="1"
+              style={{ display: 'none' }}
+              alt=""
+              src={`https://www.facebook.com/tr?id=${metaPixelId}&ev=PageView&noscript=1`}
+            />
+          </noscript>
+        )}
+        {/* End Meta Pixel (noscript) */}
+
         {children}
       </body>
     </html>

--- a/src/lib/meta/capi.ts
+++ b/src/lib/meta/capi.ts
@@ -1,0 +1,104 @@
+import { createHash } from 'crypto';
+
+/**
+ * Meta Conversions API（サーバー側）。
+ * ブラウザの Pixel と同一 event_id を送ることで重複排除される。
+ * 失敗は非致命（呼び出し側で握りつぶす）。
+ */
+
+const PIXEL_ID = process.env.NEXT_PUBLIC_META_PIXEL_ID ?? '';
+const ACCESS_TOKEN = process.env.META_CAPI_ACCESS_TOKEN ?? '';
+const TEST_EVENT_CODE = process.env.META_TEST_EVENT_CODE;
+const API_VERSION = 'v21.0';
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+/** メールは小文字・前後空白除去してから SHA256。 */
+function hashEmail(email?: string): string | undefined {
+  const normalized = email?.trim().toLowerCase();
+  return normalized ? sha256(normalized) : undefined;
+}
+
+/** 電話は数字のみにし、日本の先頭0を国番号81へ正規化してから SHA256。 */
+function hashPhone(phone?: string): string | undefined {
+  if (!phone) return undefined;
+  let digits = phone.replace(/[^0-9]/g, '');
+  if (!digits) return undefined;
+  if (digits.startsWith('0')) digits = `81${digits.slice(1)}`;
+  return sha256(digits);
+}
+
+export type MetaCapiLeadInput = {
+  eventId: string;
+  eventSourceUrl?: string;
+  email?: string;
+  phone?: string;
+  fbp?: string;
+  fbc?: string;
+  clientIpAddress?: string;
+  clientUserAgent?: string;
+  contentIds?: string[];
+  value?: number;
+  currency?: string;
+};
+
+export async function sendMetaCapiLead(input: MetaCapiLeadInput): Promise<{ ok: boolean; status?: number }> {
+  if (!PIXEL_ID || !ACCESS_TOKEN) {
+    console.warn('[CAPI] NEXT_PUBLIC_META_PIXEL_ID or META_CAPI_ACCESS_TOKEN not configured, skipping');
+    return { ok: false };
+  }
+
+  const userData: Record<string, unknown> = {};
+  const em = hashEmail(input.email);
+  const ph = hashPhone(input.phone);
+  if (em) userData.em = [em];
+  if (ph) userData.ph = [ph];
+  if (input.fbp) userData.fbp = input.fbp;
+  if (input.fbc) userData.fbc = input.fbc;
+  if (input.clientIpAddress) userData.client_ip_address = input.clientIpAddress;
+  if (input.clientUserAgent) userData.client_user_agent = input.clientUserAgent;
+
+  const customData: Record<string, unknown> = {};
+  if (input.contentIds && input.contentIds.length > 0) {
+    customData.content_ids = input.contentIds;
+    customData.content_type = 'product';
+  }
+  if (typeof input.value === 'number') customData.value = input.value;
+  if (input.currency) customData.currency = input.currency;
+
+  const body: Record<string, unknown> = {
+    data: [
+      {
+        event_name: 'Lead',
+        event_time: Math.floor(Date.now() / 1000),
+        event_id: input.eventId,
+        action_source: 'website',
+        event_source_url: input.eventSourceUrl,
+        user_data: userData,
+        custom_data: customData,
+      },
+    ],
+  };
+  if (TEST_EVENT_CODE) body.test_event_code = TEST_EVENT_CODE;
+
+  try {
+    const res = await fetch(
+      `https://graph.facebook.com/${API_VERSION}/${PIXEL_ID}/events?access_token=${ACCESS_TOKEN}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      }
+    );
+    if (!res.ok) {
+      console.error(`[CAPI] Lead send failed: ${res.status} ${await res.text()}`);
+      return { ok: false, status: res.status };
+    }
+    return { ok: true, status: res.status };
+  } catch (error) {
+    console.error('[CAPI] Lead send error:', error);
+    return { ok: false };
+  }
+}

--- a/src/lib/meta/pixel.ts
+++ b/src/lib/meta/pixel.ts
@@ -1,0 +1,53 @@
+/**
+ * Meta Pixel（ブラウザ側）ヘルパー。
+ * base ローダーは app/layout.tsx の <script> で読み込み、ここでは標準イベント送信のみを担う。
+ * CAPI（サーバー）と重複排除するため eventId を共有する。
+ */
+
+type MetaEventName = 'ViewContent' | 'AddToCart' | 'Lead' | 'Purchase';
+
+type MetaEventParams = {
+  contentIds?: string[];
+  contentName?: string;
+  value?: number;
+  currency?: string;
+};
+
+type FbqFn = (...args: unknown[]) => void;
+
+function getFbq(): FbqFn | undefined {
+  if (typeof window === 'undefined') return undefined;
+  return (window as unknown as { fbq?: FbqFn }).fbq;
+}
+
+/**
+ * Meta 標準イベントをブラウザから送信する。
+ * eventId を渡すと CAPI と同一イベントとして重複排除される。
+ */
+export function trackMeta(event: MetaEventName, params: MetaEventParams = {}, eventId?: string): void {
+  const fbq = getFbq();
+  if (!fbq) return;
+
+  const data: Record<string, unknown> = {};
+  if (params.contentIds && params.contentIds.length > 0) {
+    data.content_ids = params.contentIds;
+    data.content_type = 'product';
+  }
+  if (params.contentName) data.content_name = params.contentName;
+  if (typeof params.value === 'number') data.value = params.value;
+  if (params.currency) data.currency = params.currency;
+
+  if (eventId) {
+    fbq('track', event, data, { eventID: eventId });
+  } else {
+    fbq('track', event, data);
+  }
+}
+
+/** Pixel と CAPI で共有する一意のイベントID。 */
+export function genEventId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}


### PR DESCRIPTION
## 目的
Metaの広告運用を精緻化するため、**Meta計測をGTM経由からコード直書きへ移行**します（**Phase 2: form_applicant**＝ridejob.pmagent.jp の応募フォーム導線）。Phase 1(jobmadley)と同型。
- **CAPI併用**で iOS/ITP/ブロックの取りこぼしを削減
- **Lead を「送信成功時」に発火**（従来は完了ページ `applicants/new` の `form_complete`→GTM Lead）

> スコープ: コード化するのは **Metaのみ**。**GA4 / Google広告 / Clarity は GTM に残置**。

## 変更点
| ファイル | 内容 |
|---|---|
| `src/lib/meta/pixel.ts` (新) | `trackMeta()` / `genEventId()` |
| `src/lib/meta/capi.ts` (新) | CAPIで `Lead` をサーバー送信。em/ph SHA256・fbp/fbc/IP/UA |
| `src/app/layout.tsx` | Meta Pixel base を注入（GTMは残す） |
| `useApplicationFormState.ts` | 送信成功時に `Lead`（eventID共有）＋ body に `metaEventId` |
| `api/applicants/route.ts` | 同一 `event_id` で CAPI `Lead`（既存の Lark/メール/SMS と並列） |
| `README.md` | Meta系の環境変数を追記 |

## 設計の要点
- このLP導線は特定求人に紐づかないため **`content_ids` なし**（カタログ商品ひも付けは jobmadley 側のViewContent/AddToCart/Leadが担う）。
- **Lead はクライアント(pixel)＋サーバー(CAPI)を同一 `event_id` で送信**し重複排除。

## 必要な環境変数（Vercel）
```env
NEXT_PUBLIC_META_PIXEL_ID=1945615652686189
META_CAPI_ACCESS_TOKEN=<Events Manager>で発行・秘匿   # 未設定だとCAPIはスキップ
META_TEST_EVENT_CODE=<検証時のみ>
```

## マージ前後に必要な「コード外」作業（重要）
- [ ] **GTMの完了ページ `form_complete`→Lead を停止** ← これをやらないと **Lead二重計上**（送信時Lead＋完了ページLead）。`form_complete` 自体はGA4用に残してOK、停止するのは**Meta Leadタグのみ**
- [ ] GTM内の **FB Pixel base / PageView** も停止（コードのbaseと二重になるため）
- [ ] `META_CAPI_ACCESS_TOKEN` を Vercel に設定
- [ ] **Phase 1(jobmadley #7) と歩調を合わせる**（同一ピクセル `1945615652686189`）

## 検証
- [x] `tsc --noEmit` 通過
- [ ] ESLint: 本リポジトリは `next lint` が現Nextで非対応＋`@eslint/eslintrc` FlatCompat の循環バグでローカル実行不可（**本変更起因ではない**）。コードは lint 通過済みの #7 と同型
- [ ] preview で送信→**Pixel Helper / テストイベント**で Lead が**重複排除**されるか

## Follow-up（本PRに含まない）
- **coupang 導線**（`useCoupangForm` / `api/coupang/applicants`）への同等実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)