### PR TITLE
fix(meta): 広告ID(ad.id)を utm_id から優先取得するよう変更

### DIFF
--- a/src/app/api/applicants/route.ts
+++ b/src/app/api/applicants/route.ts
@@ -22,7 +22,8 @@ type UTMParams = {
   utm_campaign?: string;
   utm_term?: string;
   utm_creative?: string;
-  utm_content?: string; // Meta広告: {{ad.id}} を想定
+  utm_content?: string; // Meta広告: {{ad.name}}（広告名）
+  utm_id?: string; // Meta広告: {{ad.id}}（広告ID）
 };
 
 type ApplicantFormData = {
@@ -209,13 +210,16 @@ export async function POST(request: NextRequest) {
     console.log('Generated media name:', mediaName, 'isCoupang:', isCoupang);
 
     // Meta広告の広告ID(ad.id)から広告画像URLを解決する。
-    // 入稿URLに utm_content={{ad.id}} を仕込む想定。後方互換で utm_creative が数値なら ad.id とみなす。
+    // 入稿URLの utm_id={{ad.id}} を優先。後方互換で utm_content / utm_creative が数値なら ad.id とみなす。
+    // ※ utm_content は {{ad.name}}（広告名）、utm_term は {{adset.id}} のため ad.id には使わない。
     const isMetaInflowForImage = isCoupang || isMetaUtmSource(utmParams?.utm_source);
-    const adId = isLikelyAdId(utmParams?.utm_content)
-      ? (utmParams?.utm_content as string)
-      : isLikelyAdId(utmParams?.utm_creative)
-        ? (utmParams?.utm_creative as string)
-        : '';
+    const adId = isLikelyAdId(utmParams?.utm_id)
+      ? (utmParams?.utm_id as string)
+      : isLikelyAdId(utmParams?.utm_content)
+        ? (utmParams?.utm_content as string)
+        : isLikelyAdId(utmParams?.utm_creative)
+          ? (utmParams?.utm_creative as string)
+          : '';
     let adImageUrl = '';
     let adCreativeId = '';
     if (isMetaInflowForImage && adId) {
@@ -305,6 +309,7 @@ ${additionalFields ? `${additionalFields}\n` : ''}電話番号: ${formData.phone
           utm_term: utmParams?.utm_term || '',
           utm_creative: utmParams?.utm_creative || '',
           utm_content: utmParams?.utm_content || '',
+          utm_id: utmParams?.utm_id || '',
           ad_id: adId,
           ad_creative_id: adCreativeId,
           ad_image_url: adImageUrl,
@@ -437,6 +442,7 @@ ${additionalFields ? `${additionalFields}\n` : ''}電話番号: ${formData.phone
           utm_term: utmParams?.utm_term || '',
           utm_creative: utmParams?.utm_creative || '',
           utm_content: utmParams?.utm_content || '',
+          utm_id: utmParams?.utm_id || '',
           ad_id: adId,
           ad_creative_id: adCreativeId,
           ad_image_url: adImageUrl,

--- a/src/app/api/coupang/applicants/route.ts
+++ b/src/app/api/coupang/applicants/route.ts
@@ -13,7 +13,8 @@ type UTMParams = {
   utm_campaign?: string;
   utm_term?: string;
   utm_creative?: string;
-  utm_content?: string; // Meta広告: {{ad.id}} を想定
+  utm_content?: string; // Meta広告: {{ad.name}}（広告名）
+  utm_id?: string; // Meta広告: {{ad.id}}（広告ID）
 };
 
 type CoupangSubmission = CoupangFormData & {
@@ -75,12 +76,15 @@ export async function POST(request: NextRequest) {
     const birthDateLabel = formData.birthDate || '未入力';
 
     // Meta広告の広告ID(ad.id)から広告画像URLを解決する（Coupangは常にMeta流入）。
-    // 入稿URLに utm_content={{ad.id}} を仕込む想定。後方互換で utm_creative が数値なら ad.id とみなす。
-    const adId = isLikelyAdId(utmParams?.utm_content)
-      ? (utmParams?.utm_content as string)
-      : isLikelyAdId(utmParams?.utm_creative)
-        ? (utmParams?.utm_creative as string)
-        : '';
+    // 入稿URLの utm_id={{ad.id}} を優先。後方互換で utm_content / utm_creative が数値なら ad.id とみなす。
+    // ※ utm_content は {{ad.name}}（広告名）、utm_term は {{adset.id}} のため ad.id には使わない。
+    const adId = isLikelyAdId(utmParams?.utm_id)
+      ? (utmParams?.utm_id as string)
+      : isLikelyAdId(utmParams?.utm_content)
+        ? (utmParams?.utm_content as string)
+        : isLikelyAdId(utmParams?.utm_creative)
+          ? (utmParams?.utm_creative as string)
+          : '';
     let adImageUrl = '';
     let adCreativeId = '';
     if (adId) {
@@ -153,6 +157,7 @@ export async function POST(request: NextRequest) {
           utm_term: utmParams?.utm_term || '',
           utm_creative: utmParams?.utm_creative || '',
           utm_content: utmParams?.utm_content || '',
+          utm_id: utmParams?.utm_id || '',
           ad_id: adId,
           ad_creative_id: adCreativeId,
           ad_image_url: adImageUrl,
@@ -203,6 +208,7 @@ export async function POST(request: NextRequest) {
           utm_term: utmParams?.utm_term || '',
           utm_creative: utmParams?.utm_creative || '',
           utm_content: utmParams?.utm_content || '',
+          utm_id: utmParams?.utm_id || '',
           ad_id: adId,
           ad_creative_id: adCreativeId,
           ad_image_url: adImageUrl,

--- a/src/app/components/application-form/hooks/useApplicationFormState.ts
+++ b/src/app/components/application-form/hooks/useApplicationFormState.ts
@@ -591,7 +591,8 @@ export function useApplicationFormState({ showLoadingScreen, imagesToPreload, va
           utm_campaign: urlParams.get('utm_campaign') || '',
           utm_term: urlParams.get('utm_term') || '',
           utm_creative: urlParams.get('utm_creative') || '',
-          utm_content: urlParams.get('utm_content') || '', // Meta広告: {{ad.id}} を想定
+          utm_content: urlParams.get('utm_content') || '', // Meta広告: {{ad.name}}（広告名）
+          utm_id: urlParams.get('utm_id') || '', // Meta広告: {{ad.id}}（広告ID）
         };
 
         const birthDateString = formData.birthDate.length === 8

--- a/src/app/components/coupang-form/hooks/useCoupangForm.ts
+++ b/src/app/components/coupang-form/hooks/useCoupangForm.ts
@@ -80,7 +80,8 @@ export function useCoupangForm() {
         utm_campaign: urlParams.get('utm_campaign') || undefined,
         utm_term: urlParams.get('utm_term') || undefined,
         utm_creative: urlParams.get('utm_creative') || undefined,
-        utm_content: urlParams.get('utm_content') || undefined, // Meta広告: {{ad.id}} を想定
+        utm_content: urlParams.get('utm_content') || undefined, // Meta広告: {{ad.name}}（広告名）
+        utm_id: urlParams.get('utm_id') || undefined, // Meta広告: {{ad.id}}（広告ID）
       };
 
       // GTMイベント送信

--- a/src/app/components/coupang-form/hooks/useCoupangFormState.ts
+++ b/src/app/components/coupang-form/hooks/useCoupangFormState.ts
@@ -193,7 +193,8 @@ export function useCoupangFormState() {
           utm_campaign: urlParams.get('utm_campaign') || undefined,
           utm_term: urlParams.get('utm_term') || undefined,
           utm_creative: urlParams.get('utm_creative') || undefined,
-          utm_content: urlParams.get('utm_content') || undefined, // Meta広告: {{ad.id}} を想定
+          utm_content: urlParams.get('utm_content') || undefined, // Meta広告: {{ad.name}}（広告名）
+          utm_id: urlParams.get('utm_id') || undefined, // Meta広告: {{ad.id}}（広告ID）
         };
 
         // GTMイベント送信


### PR DESCRIPTION
## 背景 / 問題
Meta広告の現行カスタムパラメータ設計は以下:
```
utm_source={{site_source_name}}&utm_medium=ad&utm_campaign={{campaign.name}}-{{adset.name}}&utm_content={{ad.name}}&utm_id={{ad.id}}&utm_term={{adset.id}}
```
- `utm_content` = `{{ad.name}}`（広告名）… 数字にならないため従来ロジックでは ad.id と判定されない
- `utm_id` = `{{ad.id}}`（広告ID）… 本来ここに ad.id がある

このため `ad.id` が解決できず、Lark Base に `ad_id` / `ad_image_url` が登録されないケースがあった。

## 変更内容
- クライアント3フック（application-form / coupang×2）で `utm_id` を取得・送信
- `UTMParams` 型に `utm_id` を追加（applicants / coupang 両ルート）
- ad.id 抽出の優先順位を **`utm_id` → `utm_content` → `utm_creative`** に変更
  - `utm_content` / `utm_creative` は後方互換の保険
  - `utm_term`（`{{adset.id}}`）は ad.id ではないため使用しない
- Lark Base 送信 payload に `utm_id` を追加

## 検証
- `npx tsc --noEmit`：エラー0件
- 現行スキームのURLで `utm_id` から ad.id が解決されることをシミュレーションで確認

## 注意点 ⚠️
旧スキームのまま配信中の広告（`utm_id` に ad.id 以外の数値が入るもの）がある場合、解決される ad.id が変わる可能性があります。稼働中キャンペーンのURL設定が新スキームに揃っているか要確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)