### PR TITLE
feat(coupang): クーパン導線に直Meta Lead + CAPI を追加

### DIFF
--- a/src/app/api/coupang/applicants/route.ts
+++ b/src/app/api/coupang/applicants/route.ts
@@ -6,6 +6,7 @@ import {
 } from '@/app/components/coupang-form/constants';
 import { getCoupangStep1Options } from '../step1-options/options';
 import { resolveAdImageUrl, isLikelyAdId } from '@/lib/meta/resolveAdImage';
+import { sendMetaCapiLead } from '@/lib/meta/capi';
 
 type UTMParams = {
   utm_source?: string;
@@ -19,6 +20,7 @@ type UTMParams = {
 
 type CoupangSubmission = CoupangFormData & {
   utmParams?: UTMParams;
+  metaEventId?: string;
 };
 
 
@@ -190,6 +192,25 @@ export async function POST(request: NextRequest) {
               console.log('Lark Base webhook triggered successfully');
             }
           })()
+        );
+      }
+
+      // Meta Conversions API（Lead）— 非致命。eventId が無ければスキップ
+      if (typeof submissionData.metaEventId === 'string' && submissionData.metaEventId) {
+        const capiUserAgent = request.headers.get('user-agent') || '';
+        const capiClientIp = (request.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() || '';
+        const capiReferer = request.headers.get('referer') || '';
+        tasks.push(
+          sendMetaCapiLead({
+            eventId: submissionData.metaEventId,
+            eventSourceUrl: capiReferer,
+            email: formData.email,
+            phone: formData.phoneNumber,
+            fbp: request.cookies.get('_fbp')?.value,
+            fbc: request.cookies.get('_fbc')?.value,
+            clientIpAddress: capiClientIp || undefined,
+            clientUserAgent: capiUserAgent || undefined,
+          }).then(() => {})
         );
       }
 

--- a/src/app/components/coupang-form/hooks/useCoupangFormState.ts
+++ b/src/app/components/coupang-form/hooks/useCoupangFormState.ts
@@ -9,6 +9,7 @@ import {
   validateStep4,
   validateAllSteps,
 } from '../utils/coupangValidators';
+import { genEventId, trackMeta } from '@/lib/meta/pixel';
 
 declare global {
   interface Window {
@@ -202,6 +203,9 @@ export function useCoupangFormState() {
           form_name: 'coupang_rocketnow_application',
         });
 
+        // Pixel と CAPI で共有する eventId（重複排除用）
+        const metaEventId = genEventId();
+
         const response = await fetch(apiPath('/api/coupang/applicants'), {
           method: 'POST',
           headers: {
@@ -210,6 +214,7 @@ export function useCoupangFormState() {
           body: JSON.stringify({
             ...formData,
             utmParams,
+            metaEventId,
           }),
         });
 
@@ -222,6 +227,9 @@ export function useCoupangFormState() {
 
         await response.json();
         setIsFormDirty(false);
+
+        // 送信成功時に Meta Lead を発火（サーバーCAPIと同一 eventId で重複排除）
+        trackMeta('Lead', { value: 0, currency: 'JPY' }, metaEventId);
 
         // サンクスページへ遷移
         router.push('/coupang/applicants/new');


### PR DESCRIPTION
## 目的
クーパン(ロケットナウ)導線のMeta計測をコード化。現状この導線は **GTMのform_submitのみ** でMeta Lead計測が無く、GTM停止中はクーパンのMeta CVが取れていない。他導線と同じ直ピクセル＋CAPIに揃える。

## 変更（能動パスのみ）
能動パスは `CoupangStepForm → useCoupangFormState → /api/coupang/applicants`（`useCoupangForm`系=`CoupangApplicationForm`/legacyは未使用）。
- **client** `useCoupangFormState.ts`: 送信時に `genEventId()` → bodyに `metaEventId`、成功後 `trackMeta('Lead', {value:0, currency:'JPY'}, metaEventId)`
- **server** `api/coupang/applicants/route.ts`: 同一 `eventId` で `sendMetaCapiLead`（em/ph SHA256、fbp/fbc/IP/UA、非致命でPromise.allSettledに合流）

求人特定の無い導線のため `content_ids` は付けず汎用Lead（他LP導線と同仕様）。Meta Pixel base は root layout から `/coupang`（nested layout）へ継承済み。

## 検証
- ✅ `tsc --noEmit` 通過 / ✅ `next build` 通過
- デプロイ後: Events Manager のテストイベントで Lead が **pixel＋CAPI 同一 event_id で重複排除**されることを確認

## 関連
GTMのクーパンMetaタグは停止中のまま（本コードに一本化）。将来的に他Metaタグ同様GTMから削除推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)